### PR TITLE
feat(backend): stubbed /ifs/run with SQLite run log and toy metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Open http://localhost:8000/health and expect {"status":"ok"}.
 ## Tests
 cd backend
 pytest -q
+
+## Stubbed IFs run
+POST /ifs/run with a JSON body (e.g. {"parameters":{"tfrmin":1.5}}) returns a run_id, a toy metric, and a fake output.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,26 @@
 from fastapi import FastAPI
 from .settings import settings
+from .storage.db import init_db, record_run
+from .runner import apply_inputs_stub, run_ifs_stub
+from .metrics import metric_stub
 
 app = FastAPI(title="BIGPOPA API")
+
+
+@app.on_event("startup")
+def startup():
+    init_db()
+
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.post("/ifs/run")
+def ifs_run(config: dict):
+    apply_inputs_stub(config)
+    output = run_ifs_stub()
+    metric = metric_stub(output)
+    run_id = record_run(config, output, metric, "success")
+    return {"run_id": run_id, "metric": metric, "output": output}

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,3 @@
+def metric_stub(output: dict) -> float:
+    # Toy objective: distance from 102.0 (smaller is better)
+    return abs(output["POP_2019"] - 102.0)

--- a/backend/app/runner.py
+++ b/backend/app/runner.py
@@ -1,0 +1,13 @@
+import time, random
+
+
+def apply_inputs_stub(config: dict) -> None:
+    # Placeholder: later we will edit Working.sce / IFsBase.run.db here
+    _ = config
+
+
+def run_ifs_stub() -> dict:
+    # Simulate a model run
+    time.sleep(0.2)
+    # Fake output value to feed a toy metric
+    return {"POP_2019": random.uniform(100.0, 105.0)}

--- a/backend/app/storage/db.py
+++ b/backend/app/storage/db.py
@@ -1,0 +1,25 @@
+import sqlite3, json, time
+from ..settings import settings
+
+
+def init_db():
+    with sqlite3.connect(settings.DB_PATH) as con:
+        con.execute("""
+        CREATE TABLE IF NOT EXISTS runs(
+            run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts REAL NOT NULL,
+            config_json TEXT NOT NULL,
+            output_json TEXT NOT NULL,
+            metric REAL NOT NULL,
+            status TEXT NOT NULL
+        )
+        """)
+
+
+def record_run(config: dict, output: dict, metric: float, status: str = "success") -> int:
+    with sqlite3.connect(settings.DB_PATH) as con:
+        cur = con.execute(
+            "INSERT INTO runs(ts, config_json, output_json, metric, status) VALUES (?,?,?,?,?)",
+            (time.time(), json.dumps(config), json.dumps(output), metric, status)
+        )
+        return cur.lastrowid

--- a/backend/tests/test_run_stub.py
+++ b/backend/tests/test_run_stub.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_ifs_run_stub():
+    c = TestClient(app)
+    payload = {"parameters": {"tfrmin": 1.5}}
+    r = c.post("/ifs/run", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert "run_id" in data and data["run_id"] > 0
+    assert "metric" in data and isinstance(data["metric"], float)
+    assert "output" in data and "POP_2019" in data["output"]


### PR DESCRIPTION
## Summary
- add stubbed IFs runner, toy metric, and SQLite-backed run recorder
- expose POST /ifs/run that applies inputs, records a stub run, and returns metric and output
- document the new stubbed run endpoint and add a regression test for it

## Testing
- `pytest -q` *(fails: missing FastAPI dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc428676cc8327b4557a85e18564f3