### PR TITLE
docs: clarify base year handling in /ifs/check and expand README with current app status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ pytest -q
 
 ## Stubbed IFs run
 POST /ifs/run with a JSON body (e.g. {"parameters":{"tfrmin":1.5}}) returns a run_id, a toy metric, and a fake output.
+
+## Current status
+
+As of now, the BIGPOPA backend can:
+
+- Serve a FastAPI app with a `/health` endpoint
+- Run a stubbed IFs run via `/ifs/run`  
+  - Accepts a JSON config  
+  - Produces a fake output and toy metric  
+  - Logs each run into a local SQLite database (`bigpopa.db`)
+- Validate an IFs installation folder via `/ifs/check`  
+  - Checks presence of `ifs.exe`, `IFsInit.db`, key subfolders (`net8`, `RUNFILES`, `Scenario`, `DATA`)  
+  - Ensures required data files exist in `DATA`  
+  - Extracts the model base year from `IFsInit.db`
+
+This provides the skeleton plumbing: API, stubbed run logging, and IFs environment validation. Next stages will implement real IFs subprocess calls, results parsing, and optimization loop logic.

--- a/backend/app/ifscheck.py
+++ b/backend/app/ifscheck.py
@@ -1,0 +1,80 @@
+import os
+import sqlite3
+from typing import Optional
+
+REQUIRED_ROOT_FILES = ["ifs.exe", "IFsInit.db"]
+REQUIRED_DATA_FILES = ["SAMBase.db", "DataDict.db", "IFsHistSeries.db"]
+REQUIRED_FOLDERS = ["net8", "RUNFILES", "Scenario", "DATA"]
+
+
+def _extract_year(raw_value: object) -> Optional[int]:
+    if raw_value is None:
+        return None
+    try:
+        if isinstance(raw_value, str):
+            raw_value = raw_value.strip()
+            if not raw_value:
+                return None
+        return int(float(raw_value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _fetch_year(cur: sqlite3.Cursor, like_pattern: str) -> Optional[int]:
+    cur.execute(
+        "SELECT Value FROM IFsInit WHERE Variable LIKE ? ORDER BY Variable LIMIT 1",
+        (like_pattern,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+    return _extract_year(row[0])
+
+
+def validate_ifs_folder(path: str) -> dict:
+    missing = []
+
+    # 1. Root files
+    for f in REQUIRED_ROOT_FILES:
+        if not os.path.exists(os.path.join(path, f)):
+            missing.append(f)
+
+    # 2. Required folders
+    for folder in REQUIRED_FOLDERS:
+        if not os.path.isdir(os.path.join(path, folder)):
+            missing.append(folder)
+
+    # 3. Data folder files
+    data_folder = os.path.join(path, "DATA")
+    for f in REQUIRED_DATA_FILES:
+        if not os.path.exists(os.path.join(data_folder, f)):
+            missing.append(f"DATA/{f}")
+
+    base_year: Optional[int] = None
+
+    # 4. Extract base year from IFsInit.db
+    init_db = os.path.join(path, "IFsInit.db")
+    if os.path.exists(init_db):
+        try:
+            with sqlite3.connect(init_db) as con:
+                cur = con.cursor()
+                history_year = _fetch_year(cur, "LastYearHistory%")
+                forecast_year = _fetch_year(cur, "FirstYearForecast%")
+
+            if history_year and forecast_year:
+                # Prefer the last historical year when available; fall back to
+                # the forecast start if it's the only consistent option.
+                if history_year <= forecast_year:
+                    base_year = history_year
+                else:
+                    base_year = forecast_year
+            else:
+                base_year = history_year or forecast_year
+        except sqlite3.Error:
+            base_year = None
+
+    return {
+        "valid": len(missing) == 0,
+        "missing": missing,
+        "base_year": base_year,
+    }


### PR DESCRIPTION
## Summary
- add helper routines for parsing IFsInit metadata so /ifs/check consistently derives a base year
- prefer the last historical year when extracting the IFs base year and guard against malformed values
- document the API endpoints and IFs validation behavior in a new README "Current status" section

## Testing
- `pytest -q` *(fails: missing FastAPI dependency; pip install blocked by proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc47fd0c2c8327b0ddfcec35615f6f