### PR TITLE
feat(frontend): scaffold React app with IFs folder check UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ uvicorn app.main:app --reload
 
 Open http://localhost:8000/health and expect {"status":"ok"}.
 
+## Dev (frontend)
+cd frontend
+npm install
+npm run dev
+
+Open http://localhost:5173 in your browser. Type an IFs folder path into the form and click **Validate** to send a request to the backend checker.
+
 ## Tests
 cd backend
 pytest -q
@@ -20,13 +27,13 @@ POST /ifs/run with a JSON body (e.g. {"parameters":{"tfrmin":1.5}}) returns a ru
 As of now, the BIGPOPA backend can:
 
 - Serve a FastAPI app with a `/health` endpoint
-- Run a stubbed IFs run via `/ifs/run`  
-  - Accepts a JSON config  
-  - Produces a fake output and toy metric  
+- Run a stubbed IFs run via `/ifs/run`
+  - Accepts a JSON config
+  - Produces a fake output and toy metric
   - Logs each run into a local SQLite database (`bigpopa.db`)
-- Validate an IFs installation folder via `/ifs/check`  
-  - Checks presence of `ifs.exe`, `IFsInit.db`, key subfolders (`net8`, `RUNFILES`, `Scenario`, `DATA`)  
-  - Ensures required data files exist in `DATA`  
+- Validate an IFs installation folder via `/ifs/check`
+  - Checks presence of `ifs.exe`, `IFsInit.db`, key subfolders (`net8`, `RUNFILES`, `Scenario`, `DATA`)
+  - Ensures required data files exist in `DATA`
   - Extracts the model base year from `IFsInit.db`
 
 This provides the skeleton plumbing: API, stubbed run logging, and IFs environment validation. Next stages will implement real IFs subprocess calls, results parsing, and optimization loop logic.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.DS_Store
+dist
+.env.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BIGPOPA Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bigpopa-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,102 @@
+import { FormEvent, useState } from "react";
+import { checkIFsFolder } from "./api";
+
+type CheckResult = {
+  valid: boolean;
+  base_year?: number | null;
+  missing?: string[];
+};
+
+function App() {
+  const [path, setPath] = useState("");
+  const [result, setResult] = useState<CheckResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement> | MouseEvent) => {
+    event.preventDefault?.();
+    if (!path.trim()) {
+      setError("Please provide a folder path.");
+      setResult(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await checkIFsFolder(path.trim());
+      setResult(res);
+    } catch (err) {
+      setError("Failed to reach backend. Ensure it is running on port 8000.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <header className="header">
+        <h1>BIGPOPA - IFs Folder Check</h1>
+        <p className="subtitle">
+          Enter the path to your IFs installation and validate it against the backend API.
+        </p>
+      </header>
+
+      <form className="form" onSubmit={handleSubmit as (e: FormEvent<HTMLFormElement>) => void}>
+        <label htmlFor="path" className="label">
+          IFs folder path
+        </label>
+        <div className="input-row">
+          <input
+            id="path"
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="C:\\Program Files\\IFs"
+            className="text-input"
+          />
+          <button type="submit" className="button" disabled={loading}>
+            {loading ? "Validating..." : "Validate"}
+          </button>
+        </div>
+      </form>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {result && (
+        <section className="results">
+          <h2>Validation Results</h2>
+          <div className="result-grid">
+            <div>
+              <span className="label">Valid</span>
+              <span className={result.valid ? "value success" : "value error"}>
+                {String(result.valid)}
+              </span>
+            </div>
+            <div>
+              <span className="label">Base Year</span>
+              <span className="value">{result.base_year ?? "N/A"}</span>
+            </div>
+          </div>
+
+          {result.missing && result.missing.length > 0 ? (
+            <div className="missing">
+              <span className="label">Missing files</span>
+              <ul>
+                {result.missing.map((file) => (
+                  <li key={file}>{file}</li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="label">No missing files reported.</p>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,22 @@
+export type CheckResponse = {
+  valid: boolean;
+  base_year?: number | null;
+  missing?: string[];
+};
+
+export async function checkIFsFolder(path: string): Promise<CheckResponse> {
+  const response = await fetch("http://localhost:8000/ifs/check", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ path })
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Request failed");
+  }
+
+  return response.json();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,156 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #f5f7fb;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #f5f7fb 0%, #eef1f7 100%);
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.subtitle {
+  color: #4a5568;
+  margin-top: 0.5rem;
+}
+
+.form {
+  background: #ffffff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 15px 35px rgba(65, 84, 241, 0.12);
+  border: 1px solid rgba(72, 84, 96, 0.1);
+}
+
+.label {
+  display: block;
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 0.75rem;
+}
+
+.input-row {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.text-input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5e0;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #5a67d8;
+  box-shadow: 0 0 0 3px rgba(90, 103, 216, 0.2);
+}
+
+.button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(118, 75, 162, 0.25);
+}
+
+.alert {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  font-weight: 500;
+}
+
+.alert-error {
+  background: rgba(245, 101, 101, 0.15);
+  color: #c53030;
+  border: 1px solid rgba(245, 101, 101, 0.3);
+}
+
+.results {
+  margin-top: 2rem;
+  background: #ffffff;
+  padding: 1.75rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 25px rgba(72, 89, 241, 0.15);
+  border: 1px solid rgba(72, 84, 96, 0.08);
+}
+
+.results h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.value {
+  display: inline-block;
+  margin-top: 0.4rem;
+  font-size: 1.1rem;
+}
+
+.value.success {
+  color: #2f855a;
+}
+
+.value.error {
+  color: #c53030;
+}
+
+.missing ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  color: #4a5568;
+}
+
+@media (max-width: 600px) {
+  .input-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript frontend in the new `frontend` directory
- build an IFs folder validation interface that calls the backend `/ifs/check` endpoint and displays the response
- add frontend development instructions to the README

## Testing
- `npm install` *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49def3888327a4202008e9c45b90