### PR TITLE
docs: add local run guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,48 @@
 # BIGPOPA (local web app)
+
 Local-first application for automating and optimizing IFs model runs.
 
-## Dev (backend)
-cd backend
-pip install -e .
-uvicorn app.main:app --reload
+## Run the app locally
 
-Open http://localhost:8000/health and expect {"status":"ok"}.
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/<your-org>/ifs_autotune.git
+   cd ifs_autotune
+   ```
 
-## Dev (frontend)
-cd frontend
-npm install
-npm run dev
+2. **Start the backend API**
+   - Ensure you have Python 3.11 or later installed.
+   - (Optional but recommended) create and activate a virtual environment.
+   - Install dependencies and launch the FastAPI server:
+     ```bash
+     cd backend
+     pip install -e .
+     uvicorn app.main:app --reload
+     ```
+   - The backend exposes a health endpoint at http://localhost:8000/health which should respond with `{ "status": "ok" }`.
 
-Open http://localhost:5173 in your browser. Type an IFs folder path into the form and click **Validate** to send a request to the backend checker.
+3. **Start the frontend**
+   - Ensure you have Node.js 18+ and npm available.
+   - In a new terminal window, install dependencies and run the dev server:
+     ```bash
+     cd frontend
+     npm install
+     npm run dev
+     ```
+   - Open http://localhost:5173 in your browser. Type an IFs folder path into the form and click **Validate** to send a request to the backend checker.
+
+Once both servers are running, the frontend will communicate with the backend API locally.
 
 ## Tests
+
+```bash
 cd backend
 pytest -q
+```
 
 ## Stubbed IFs run
-POST /ifs/run with a JSON body (e.g. {"parameters":{"tfrmin":1.5}}) returns a run_id, a toy metric, and a fake output.
+
+`POST /ifs/run` with a JSON body (e.g. `{ "parameters": { "tfrmin": 1.5 } }`) returns a `run_id`, a toy metric, and a fake output.
 
 ## Current status
 


### PR DESCRIPTION
## Summary
- rewrite the README run instructions into a numbered, step-by-step local setup guide
- document backend and frontend prerequisites alongside the commands to start each service

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc4c800be0832785c4d2e917e9bf4d