### PR TITLE
Add combined dev server launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,32 @@ Local-first application for automating and optimizing IFs model runs.
    - Using Conda or another environment manager works as well—just create and activate your environment before installing dependencies.
    - If you prefer to work without a virtual environment, ensure the following commands are run in the Python environment where you want the dependencies installed.
 
-3. **Start the backend API**
+3. **Install backend dependencies**
    - Ensure you have Python 3.11 or later installed.
-   - Install dependencies and launch the FastAPI server:
+   - Install the FastAPI app in editable mode:
      ```bash
      cd backend
      pip install -e .
-     uvicorn app.main:app --reload
+     cd ..
      ```
-   - The backend exposes a health endpoint at http://localhost:8000/health which should respond with `{ "status": "ok" }`.
+   - The backend exposes a health endpoint at http://localhost:8000/health which should respond with `{ "status": "ok" }` once the server is running.
 
-4. **Start the frontend**
+4. **Install frontend dependencies**
    - Ensure you have Node.js 18+ and npm available.
-   - In a new terminal window, install dependencies and run the dev server:
+   - Install packages with:
      ```bash
      cd frontend
      npm install
-     npm run dev
+     cd ..
      ```
-   - Open http://localhost:5173 in your browser. Type an IFs folder path into the form and click **Validate** to send a request to the backend checker.
 
-Once both servers are running, the frontend will communicate with the backend API locally.
+5. **Launch the combined dev environment**
+   - Run the helper script from the project root to start both servers with hot reload:
+     ```bash
+     python dev.py
+     # or, if you prefer, ./dev.py
+     ```
+   - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser, type an IFs folder path into the form, and click **Validate** to send a request to the backend checker.
 
 ## Tests
 

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Run the BIGPOPA backend and frontend dev servers together."""
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+SERVICES = (
+    {
+        "name": "backend",
+        "cmd": [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"],
+        "cwd": ROOT / "backend",
+    },
+    {
+        "name": "frontend",
+        "cmd": ["npm", "run", "dev"],
+        "cwd": ROOT / "frontend",
+    },
+)
+
+processes: list[tuple[str, subprocess.Popen[bytes]]] = []
+_shutting_down = False
+
+
+def _shutdown(signum: int | None = None, frame: object | None = None, *, reason: str | None = None, exit_code: int = 0) -> None:
+    """Terminate all running child processes and exit."""
+    del frame  # Unused.
+    global _shutting_down
+    if _shutting_down:
+        return
+    _shutting_down = True
+
+    if reason:
+        print(f"\n{reason}")
+    print("Stopping development environment...")
+
+    for name, proc in processes:
+        if proc.poll() is None:
+            print(f"Terminating {name} server...")
+            proc.terminate()
+
+    for name, proc in processes:
+        if proc.poll() is None:
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                print(f"Forcing {name} server to exit...")
+                proc.kill()
+                proc.wait()
+
+        if proc.returncode and exit_code == 0:
+            exit_code = proc.returncode
+
+    sys.exit(exit_code)
+
+
+def main() -> None:
+    """Launch both development servers and monitor them."""
+    if hasattr(signal, "SIGINT"):
+        signal.signal(signal.SIGINT, _shutdown)
+    if hasattr(signal, "SIGTERM"):
+        signal.signal(signal.SIGTERM, _shutdown)
+
+    for service in SERVICES:
+        name = service["name"]
+        cmd = service["cmd"]
+        cwd = service["cwd"]
+        print(f"Starting {name} server: {' '.join(cmd)}")
+        try:
+            proc = subprocess.Popen(cmd, cwd=cwd)
+        except FileNotFoundError as exc:
+            _shutdown(reason=f"Failed to start {name} server: {exc}", exit_code=1)
+            return
+        processes.append((name, proc))
+
+    try:
+        while True:
+            for name, proc in processes:
+                retcode = proc.poll()
+                if retcode is not None:
+                    exit_status = retcode if retcode != 0 else 1
+                    _shutdown(reason=f"{name} server exited with code {retcode}.", exit_code=exit_status)
+                    return
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        _shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pragma: no cover - best effort error surface
+        _shutdown(reason=f"Encountered unexpected error: {exc}", exit_code=1)


### PR DESCRIPTION
## Summary
- add a top-level `dev.py` helper that launches the backend and frontend dev servers together
- document the combined dev workflow in the README

## Testing
- python -m py_compile dev.py

------
https://chatgpt.com/codex/tasks/task_e_68cc53de33e88327bc70658ac42dd252