### PR TITLE
Fix BaseSettings import for pydantic v2

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
   "fastapi",
   "uvicorn[standard]",
   "pydantic",
+  "pydantic-settings",
   "pytest",
   "httpx"
 ]


### PR DESCRIPTION
## Summary
- update the backend settings module to import `BaseSettings` from `pydantic_settings`
- declare the new `pydantic-settings` dependency in the backend pyproject so the package is installed with the backend

## Testing
- `pytest` *(fails: dependency installation for `pydantic-settings` is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc82d17b408327b63d2cefae42cf93