### PR TITLE
fix(backend): enable CORS and include /ifs/check route for frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Local-first application for automating and optimizing IFs model runs.
      # or, if you prefer, ./dev.py
      ```
    - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser, type an IFs folder path into the form, and click **Validate** to send a request to the backend checker.
+   - During development, the frontend at http://localhost:5173 must call backend APIs at http://localhost:8000. CORS middleware has been enabled to allow this. In production, the frontend can be built and served from the backend directly.
 
 ## Tests
 

--- a/backend/app/ifscheck.py
+++ b/backend/app/ifscheck.py
@@ -2,9 +2,15 @@ import os
 import sqlite3
 from typing import Optional
 
+from fastapi import APIRouter
+
 REQUIRED_ROOT_FILES = ["ifs.exe", "IFsInit.db"]
 REQUIRED_DATA_FILES = ["SAMBase.db", "DataDict.db", "IFsHistSeries.db"]
 REQUIRED_FOLDERS = ["net8", "RUNFILES", "Scenario", "DATA"]
+
+
+router = APIRouter()
+
 
 
 def _extract_year(raw_value: object) -> Optional[int]:
@@ -78,3 +84,8 @@ def validate_ifs_folder(path: str) -> dict:
         "missing": missing,
         "base_year": base_year,
     }
+
+
+@router.post("/check")
+def check_folder(payload: dict) -> dict:
+    return validate_ifs_folder(payload["path"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,29 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app import ifscheck
+
 from .settings import settings
 from .storage.db import init_db, record_run
 from .runner import apply_inputs_stub, run_ifs_stub
 from .metrics import metric_stub
 
 app = FastAPI(title="BIGPOPA API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(ifscheck.router, prefix="/ifs")
+
+
+# Ensure the database exists even when startup events are not triggered (e.g., in some
+# test harnesses).
+init_db()
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- enable CORS on the FastAPI app so the Vite dev server can call backend APIs
- register the /ifs/check endpoint via the ifscheck router for folder validation
- document the localhost frontend/backend interaction during development

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd8c85f4588327937ed3707d631978