### PR TITLE
feat(frontend): add folder picker and improved validation results display with green/red icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Local-first application for automating and optimizing IFs model runs.
      python dev.py
      # or, if you prefer, ./dev.py
      ```
-   - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser, type an IFs folder path into the form, and click **Validate** to send a request to the backend checker.
+  - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser, browse to your IFs installation with the folder picker or type the path manually, and click **Validate** to send a request to the backend checker.
    - During development, the frontend at http://localhost:5173 must call backend APIs at http://localhost:8000. CORS middleware has been enabled to allow this. In production, the frontend can be built and served from the backend directly.
 
 ## Tests

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
 import { checkIFsFolder } from "./api";
 
 type CheckResult = {
@@ -7,16 +7,76 @@ type CheckResult = {
   missing?: string[];
 };
 
+type Requirement = {
+  id: string;
+  label: string;
+};
+
+const REQUIREMENTS: Requirement[] = [
+  { id: "ifs.exe", label: "ifs.exe" },
+  { id: "IFsInit.db", label: "IFsInit.db" },
+  { id: "net8", label: "net8/" },
+  { id: "RUNFILES", label: "RUNFILES/" },
+  { id: "Scenario", label: "Scenario/" },
+  { id: "DATA", label: "DATA/" },
+  { id: "DATA/SAMBase.db", label: "DATA/SAMBase.db" },
+  { id: "DATA/DataDict.db", label: "DATA/DataDict.db" },
+  { id: "DATA/IFsHistSeries.db", label: "DATA/IFsHistSeries.db" },
+];
+
 function App() {
   const [path, setPath] = useState("");
   const [result, setResult] = useState<CheckResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement> | MouseEvent) => {
-    event.preventDefault?.();
+  const handleFolderChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) {
+      setPath("");
+      return;
+    }
+
+    const firstFile = files[0] as File & {
+      path?: string;
+      webkitRelativePath?: string;
+    };
+
+    const filePath = firstFile.path ?? "";
+    const relativePath = firstFile.webkitRelativePath ?? "";
+    let folderPath = "";
+
+    if (filePath && relativePath) {
+      folderPath = filePath.slice(0, filePath.length - relativePath.length);
+    } else if (filePath) {
+      folderPath = filePath.replace(/[\\/][^\\/]*$/, "");
+    }
+
+    folderPath = folderPath.replace(/[\\/]+$/, "");
+
+    if (!folderPath) {
+      setPath("");
+      setError("Unable to read the folder path. Please try again in Chrome or Edge.");
+      event.target.value = "";
+      return;
+    }
+
+    setPath(folderPath);
+    setResult(null);
+    setError(null);
+    event.target.value = "";
+  };
+
+  const handlePathInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPath(event.target.value);
+    setResult(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!path.trim()) {
-      setError("Please provide a folder path.");
+      setError("Please select an IFs folder before validating.");
       setResult(null);
       return;
     }
@@ -40,22 +100,32 @@ function App() {
       <header className="header">
         <h1>BIGPOPA - IFs Folder Check</h1>
         <p className="subtitle">
-          Enter the path to your IFs installation and validate it against the backend API.
+          Browse to your IFs installation folder and validate it against the backend API.
         </p>
       </header>
 
-      <form className="form" onSubmit={handleSubmit as (e: FormEvent<HTMLFormElement>) => void}>
-        <label htmlFor="path" className="label">
-          IFs folder path
+      <form className="form" onSubmit={handleSubmit}>
+        <label htmlFor="path-input" className="label">
+          IFs folder
         </label>
         <div className="input-row">
+          <label className="file-picker">
+            <span>Select folder</span>
+            <input
+              type="file"
+              className="file-input"
+              webkitdirectory="true"
+              onChange={handleFolderChange}
+            />
+          </label>
           <input
-            id="path"
+            id="path-input"
             type="text"
-            value={path}
-            onChange={(e) => setPath(e.target.value)}
-            placeholder="C:\\Program Files\\IFs"
             className="text-input"
+            value={path}
+            onChange={handlePathInputChange}
+            placeholder="Type or paste your IFs folder path"
+            autoComplete="off"
           />
           <button type="submit" className="button" disabled={loading}>
             {loading ? "Validating..." : "Validate"}
@@ -68,31 +138,27 @@ function App() {
       {result && (
         <section className="results">
           <h2>Validation Results</h2>
-          <div className="result-grid">
-            <div>
-              <span className="label">Valid</span>
-              <span className={result.valid ? "value success" : "value error"}>
-                {String(result.valid)}
-              </span>
-            </div>
-            <div>
-              <span className="label">Base Year</span>
-              <span className="value">{result.base_year ?? "N/A"}</span>
-            </div>
+          <div className={result.valid ? "status success" : "status error"}>
+            {result.valid ? "Valid ✅" : "Invalid ❌"}
+          </div>
+          <div className="base-year">
+            Base year: {result.base_year ?? "N/A"}
           </div>
 
-          {result.missing && result.missing.length > 0 ? (
-            <div className="missing">
-              <span className="label">Missing files</span>
-              <ul>
-                {result.missing.map((file) => (
-                  <li key={file}>{file}</li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <p className="label">No missing files reported.</p>
-          )}
+          <div className="requirements">
+            <h3>Required files &amp; folders</h3>
+            <ul>
+              {REQUIREMENTS.map((item) => {
+                const isMissing = result.missing?.includes(item.id);
+                return (
+                  <li key={item.id} className={isMissing ? "item error" : "item success"}>
+                    <span className="icon">{isMissing ? "❌" : "✅"}</span>
+                    <span>{item.label}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </section>
       )}
     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -52,8 +52,36 @@ body {
   align-items: center;
 }
 
+.file-picker {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #5a67d8 0%, #805ad5 100%);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+
+.file-picker:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(90, 103, 216, 0.25);
+}
+
+.file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
 .text-input {
   flex: 1;
+  min-width: 0;
   padding: 0.75rem 1rem;
   border: 1px solid #cbd5e0;
   border-radius: 0.75rem;
@@ -117,37 +145,83 @@ body {
   margin-bottom: 1rem;
 }
 
-.result-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.25rem;
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.status.success {
+  color: #276749;
+  background: rgba(72, 187, 120, 0.15);
+}
+
+.status.error {
+  color: #c53030;
+  background: rgba(245, 101, 101, 0.15);
+}
+
+.base-year {
+  font-weight: 600;
+  color: #2d3748;
   margin-bottom: 1rem;
 }
 
-.value {
-  display: inline-block;
-  margin-top: 0.4rem;
-  font-size: 1.1rem;
+.requirements h3 {
+  margin-bottom: 0.75rem;
+  color: #2d3748;
 }
 
-.value.success {
-  color: #2f855a;
+.requirements ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
 }
 
-.value.error {
+.requirements .item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 0.75rem;
+  font-weight: 500;
+}
+
+.requirements .item.success {
+  background: rgba(72, 187, 120, 0.12);
+  color: #276749;
+}
+
+.requirements .item.error {
+  background: rgba(245, 101, 101, 0.12);
   color: #c53030;
 }
 
-.missing ul {
-  margin: 0.5rem 0 0;
-  padding-left: 1.25rem;
-  color: #4a5568;
+.requirements .icon {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 @media (max-width: 600px) {
   .input-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .file-picker {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .text-input {
+    width: 100%;
   }
 
   .button {


### PR DESCRIPTION
## Summary
- provide both a folder picker and editable path field so users can browse or type their IFs directory before validation
- refresh the results view to highlight validity, base year, and each required asset with green and red icons
- document the new folder picking workflow in the frontend README instructions

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cd90170b9083279060fcacd3970e94