### PR TITLE
feat(validation): improve folder picker UI, merge net8/ifs.exe check, and return full checklist with ✅/❌ display

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Local-first application for automating and optimizing IFs model runs.
      python dev.py
      # or, if you prefer, ./dev.py
      ```
-  - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser, browse to your IFs installation with the folder picker or type the path manually, and click **Validate** to send a request to the backend checker.
+  - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser. Click **Browse** to select your IFs installation folder—the selected path will be displayed above the **Validate** button. Click **Validate** to send a request to the backend checker.
+  - Validation now checks `net8/ifs.exe` directly instead of separate `net8` + `ifs.exe` entries.
+  - Validation results display a checklist of required files/folders with ✅ or ❌ indicators.
    - During development, the frontend at http://localhost:5173 must call backend APIs at http://localhost:8000. CORS middleware has been enabled to allow this. In production, the frontend can be built and served from the backend directly.
 
 ## Tests
@@ -70,8 +72,7 @@ As of now, the BIGPOPA backend can:
   - Produces a fake output and toy metric
   - Logs each run into a local SQLite database (`bigpopa.db`)
 - Validate an IFs installation folder via `/ifs/check`
-  - Checks presence of `ifs.exe`, `IFsInit.db`, key subfolders (`net8`, `RUNFILES`, `Scenario`, `DATA`)
-  - Ensures required data files exist in `DATA`
+  - Checks for `IFsInit.db`, `DATA/SAMBase.db`, `DATA/DataDict.db`, `DATA/IFsHistSeries.db`, `net8/ifs.exe`, `RUNFILES/`, and `Scenario/`
   - Extracts the model base year from `IFsInit.db`
 
 This provides the skeleton plumbing: API, stubbed run logging, and IFs environment validation. Next stages will implement real IFs subprocess calls, results parsing, and optimization loop logic.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,12 @@
+export type RequirementCheck = {
+  file: string;
+  exists: boolean;
+};
+
 export type CheckResponse = {
   valid: boolean;
   base_year?: number | null;
-  missing?: string[];
+  requirements: RequirementCheck[];
 };
 
 export async function checkIFsFolder(path: string): Promise<CheckResponse> {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -49,7 +49,7 @@ body {
 .input-row {
   display: flex;
   gap: 1rem;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .file-picker {
@@ -79,20 +79,29 @@ body {
   cursor: pointer;
 }
 
-.text-input {
+.actions {
   flex: 1;
-  min-width: 0;
-  padding: 0.75rem 1rem;
-  border: 1px solid #cbd5e0;
-  border-radius: 0.75rem;
-  font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.text-input:focus {
-  outline: none;
-  border-color: #5a67d8;
-  box-shadow: 0 0 0 3px rgba(90, 103, 216, 0.2);
+.selected-path {
+  min-height: 3rem;
+  padding: 0.75rem 1rem;
+  border: 1px dashed #cbd5e0;
+  border-radius: 0.75rem;
+  background: #f7fafc;
+  color: #2d3748;
+  font-size: 0.95rem;
+  font-weight: 500;
+  word-break: break-word;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.selected-path.empty {
+  color: #718096;
+  font-weight: 400;
 }
 
 .button {
@@ -220,7 +229,11 @@ body {
     justify-content: center;
   }
 
-  .text-input {
+  .actions {
+    width: 100%;
+  }
+
+  .selected-path {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- replace the manual path entry with a folder picker that shows the chosen IFs directory before validation
- update the backend validator to check the consolidated list of required files/folders and return a full exists checklist
- render the checklist with ✅/❌ indicators on the frontend and refresh the README instructions for the new flow

## Testing
- npm run dev
- PYTHONPATH=backend pytest -q backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cd96ccff648327a5170cd43c43ce32