### PR TITLE
Improve folder selection and manual path entry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
 import { checkIFsFolder, type CheckResponse } from "./api";
 
 function App() {
@@ -6,6 +6,19 @@ function App() {
   const [result, setResult] = useState<CheckResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const input = fileInputRef.current;
+    if (!input) {
+      return;
+    }
+
+    input.setAttribute("directory", "");
+    input.setAttribute("webkitdirectory", "");
+    input.setAttribute("mozdirectory", "");
+    input.multiple = true;
+  }, []);
 
   const handleFolderChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -42,6 +55,12 @@ function App() {
     setResult(null);
     setError(null);
     event.target.value = "";
+  };
+
+  const handlePathInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPath(event.target.value);
+    setResult(null);
+    setError(null);
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -81,19 +100,21 @@ function App() {
           <label className="file-picker">
             <span>Browse</span>
             <input
+              ref={fileInputRef}
               type="file"
               className="file-input"
-              webkitdirectory
               onChange={handleFolderChange}
             />
           </label>
           <div className="actions">
-            <div
-              className={`selected-path${path ? "" : " empty"}`}
-              title={path || undefined}
-            >
-              {path ? path : "No folder selected"}
-            </div>
+            <input
+              type="text"
+              className="path-input"
+              placeholder="Enter or paste a folder path"
+              value={path}
+              onChange={handlePathInputChange}
+              spellCheck={false}
+            />
             <button type="submit" className="button" disabled={loading}>
               {loading ? "Validating..." : "Validate"}
             </button>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -86,7 +86,8 @@ body {
   gap: 0.75rem;
 }
 
-.selected-path {
+.path-input {
+  width: 100%;
   min-height: 3rem;
   padding: 0.75rem 1rem;
   border: 1px dashed #cbd5e0;
@@ -95,13 +96,22 @@ body {
   color: #2d3748;
   font-size: 0.95rem;
   font-weight: 500;
-  word-break: break-word;
   box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-.selected-path.empty {
+.path-input::placeholder {
   color: #718096;
   font-weight: 400;
+}
+
+.path-input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow:
+    inset 0 1px 2px rgba(15, 23, 42, 0.04),
+    0 0 0 3px rgba(102, 126, 234, 0.25);
+  background: #ffffff;
 }
 
 .button {


### PR DESCRIPTION
## Summary
- configure the file input at mount time to request directory selection across browsers
- replace the read-only path display with an editable text field so users can type or paste folder paths
- refresh styling to support the new text input while keeping existing layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdab7ea42c8327a02e2660ce9a9204