### PR TITLE
fix(frontend): enable proper folder picker by moving webkitdirectory/directory attributes into JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Local-first application for automating and optimizing IFs model runs.
      # or, if you prefer, ./dev.py
      ```
   - The backend will be available at http://localhost:8000 and the frontend at http://localhost:5173. Open the frontend in your browser. Click **Browse** to select your IFs installation folder—the selected path will be displayed above the **Validate** button. Click **Validate** to send a request to the backend checker.
+  - You can now browse for an IFs folder using the folder picker. The selected path will display automatically in the text field.
   - Validation now checks `net8/ifs.exe` directly instead of separate `net8` + `ifs.exe` entries.
   - Validation results display a checklist of required files/folders with ✅ or ❌ indicators.
    - During development, the frontend at http://localhost:5173 must call backend APIs at http://localhost:8000. CORS middleware has been enabled to allow this. In production, the frontend can be built and served from the backend directly.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,11 @@
-import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, FormEvent, useRef, useState } from "react";
 import { checkIFsFolder, type CheckResponse } from "./api";
+
+const directoryAttributes = {
+  webkitdirectory: "true",
+  directory: "",
+  mozdirectory: "",
+} satisfies Record<string, string>;
 
 function App() {
   const [path, setPath] = useState("");
@@ -7,18 +13,6 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    const input = fileInputRef.current;
-    if (!input) {
-      return;
-    }
-
-    input.setAttribute("directory", "");
-    input.setAttribute("webkitdirectory", "");
-    input.setAttribute("mozdirectory", "");
-    input.multiple = true;
-  }, []);
 
   const handleFolderChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -104,6 +98,8 @@ function App() {
               type="file"
               className="file-input"
               onChange={handleFolderChange}
+              multiple
+              {...directoryAttributes}
             />
           </label>
           <div className="actions">


### PR DESCRIPTION
## Summary
- enable the IFs folder picker by defining the directory attributes directly on the file input
- clear out the old effect that manually set directory attributes and keep path updates wired to the text field
- document the improved folder picker behavior in the frontend README instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb2e39dd08327a2cd867acc91fac3