### PR TITLE
Use IPC to validate IFs folders

### DIFF
--- a/backend/validate_ifs.py
+++ b/backend/validate_ifs.py
@@ -1,0 +1,61 @@
+"""CLI entry point for validating IFs folders.
+
+This script wraps the ``validate_ifs_folder`` helper used by the FastAPI service
+so it can be executed directly from the command line. It accepts a single folder
+path argument, runs the validation and prints the resulting JSON payload to
+stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+try:
+    from app.ifscheck import validate_ifs_folder  # type: ignore[attr-defined]  # noqa: E402
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency shim
+    if exc.name != 'fastapi':
+        raise
+
+    class _APIRouter:  # Minimal stub for fastapi.APIRouter
+        def post(self, *_args, **_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    sys.modules['fastapi'] = SimpleNamespace(APIRouter=_APIRouter)
+    from app.ifscheck import validate_ifs_folder  # type: ignore[attr-defined]  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        payload: dict[str, Any] = {
+            "valid": False,
+            "missingFiles": ["No folder path provided"],
+        }
+        print(json.dumps(payload))
+        return 1
+
+    folder_path = argv[1]
+
+    try:
+        result = validate_ifs_folder(folder_path)
+    except Exception:  # pragma: no cover - surface any unexpected error
+        payload = {"valid": False, "missingFiles": ["Python error"]}
+        print(json.dumps(payload))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    sys.exit(main(sys.argv))

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -2,4 +2,5 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electron', {
   selectFolder: async () => ipcRenderer.invoke('dialog:selectFolder'),
+  invoke: (channel, data) => ipcRenderer.invoke(channel, data),
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, FormEvent, useState } from "react";
-import { checkIFsFolder, type CheckResponse } from "./api";
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import { validateIFsFolder, type CheckResponse } from "./api";
 
 function App() {
   const [path, setPath] = useState("");
@@ -45,14 +45,17 @@ function App() {
     setResult(null);
 
     try {
-      const res = await checkIFsFolder(path.trim());
+      const res = await validateIFsFolder(path.trim());
       setResult(res);
     } catch (err) {
-      setError("Failed to reach backend. Ensure it is running on port 8000.");
+      setError("Failed to validate the IFs folder. Please try again.");
     } finally {
       setLoading(false);
     }
   };
+
+  const missingFiles = useMemo(() => result?.missingFiles ?? [], [result]);
+  const requirements = useMemo(() => result?.requirements ?? [], [result]);
 
   return (
     <div className="container">
@@ -97,20 +100,36 @@ function App() {
             <div className="base-year">Base year: {result.base_year}</div>
           )}
 
-          <div className="requirements">
-            <h3>Required files &amp; folders</h3>
-            <ul>
-              {result.requirements.map((item) => (
-                <li
-                  key={item.file}
-                  className={item.exists ? "item success" : "item error"}
-                >
-                  <span className="icon">{item.exists ? "✅" : "❌"}</span>
-                  <span>{item.file}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {requirements.length > 0 && (
+            <div className="requirements">
+              <h3>Required files &amp; folders</h3>
+              <ul>
+                {requirements.map((item) => (
+                  <li
+                    key={item.file}
+                    className={item.exists ? "item success" : "item error"}
+                  >
+                    <span className="icon">{item.exists ? "✅" : "❌"}</span>
+                    <span>{item.file}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {missingFiles.length > 0 && (
+            <div className="requirements">
+              <h3>Missing files</h3>
+              <ul>
+                {missingFiles.map((file) => (
+                  <li key={file} className="item error">
+                    <span className="icon">❌</span>
+                    <span>{file}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </section>
       )}
     </div>

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     electron?: {
       selectFolder: () => Promise<string | null>;
+      invoke: <T = unknown, R = unknown>(channel: string, data?: T) => Promise<R>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- switch the renderer API over to Electron IPC for IFs folder validation and show IPC error details in the UI
- add an Electron main-process handler that runs the Python validator script and expose a generic invoke helper in the preload script
- introduce a backend/validate_ifs.py CLI wrapper so the desktop shell can validate folders without the FastAPI server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a07e24c883278da2567d50c47006