### PR TITLE
Add IFs tuning workflow with live progress

### DIFF
--- a/backend/run_ifs.py
+++ b/backend/run_ifs.py
@@ -1,0 +1,88 @@
+"""Helper script to launch IFs runs from the desktop shell.
+
+This module exposes a thin CLI wrapper around the IFs executable so the
+Electron backend can trigger model runs without blocking the event loop. It
+accepts a handful of parameters that mirror the ones used by BIGPOPA and
+prints a JSON payload describing the outcome once the process exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import List
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Launch IFs with custom arguments.")
+    parser.add_argument("--ifs-root", required=True, help="Path to the IFs installation root.")
+    parser.add_argument("--end-year", type=int, default=2050, help="Final simulation year.")
+    parser.add_argument("--start-token", default="5", help="Starting token passed to IFs.")
+    parser.add_argument("--log", default="jrs.txt", help="Log file name to pass to IFs.")
+    parser.add_argument(
+        "--websessionid",
+        default="qsdqsqsdqsdqsdqs",
+        help="Session identifier forwarded to IFs.",
+    )
+    return parser
+
+
+def build_command(args: argparse.Namespace) -> List[str]:
+    ifs_root = os.path.abspath(args.ifs_root)
+    executable = os.path.join(ifs_root, "net8", "ifs.exe")
+    command = [
+        executable,
+        str(args.start_token),
+        str(args.end_year),
+        "-1",
+        "true",
+        "true",
+        "0",
+        "false",
+        "--log",
+        args.log,
+        "--websessionid",
+        args.websessionid,
+    ]
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    command = build_command(args)
+    ifs_root = os.path.abspath(args.ifs_root)
+    working_dir = os.path.join(ifs_root, "net8")
+
+    try:
+        process = subprocess.Popen(command, cwd=working_dir)
+    except Exception as exc:  # pragma: no cover - surface unexpected spawn errors
+        payload = {
+            "status": "error",
+            "message": str(exc),
+        }
+        print(json.dumps(payload))
+        return 1
+
+    return_code = process.wait()
+
+    payload = {
+        "end_year": args.end_year,
+        "log": args.log,
+        "session_id": args.websessionid,
+        "status": "ok" if return_code == 0 else "error",
+    }
+
+    if return_code != 0:
+        payload["message"] = f"IFs exited with code {return_code}"
+
+    print(json.dumps(payload))
+    return 0 if return_code == 0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,11 +1,14 @@
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const { spawn } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const isDev = !app.isPackaged;
+let mainWindow = null;
+let lastValidatedPath = null;
 
 function createWindow() {
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
     webPreferences: {
@@ -13,6 +16,10 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
     },
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
   });
 
   if (isDev) {
@@ -59,6 +66,18 @@ ipcMain.handle('validate-ifs-folder', async (_event, folderPath) => {
     let resolved = false;
 
     const finish = (payload) => {
+      if (
+        payload &&
+        typeof payload === 'object' &&
+        Object.prototype.hasOwnProperty.call(payload, 'valid')
+      ) {
+        if (payload.valid) {
+          lastValidatedPath = path.resolve(folderPath);
+        } else {
+          lastValidatedPath = null;
+        }
+      }
+
       if (!resolved) {
         resolved = true;
         resolve(payload);
@@ -107,5 +126,153 @@ ipcMain.handle('validate-ifs-folder', async (_event, folderPath) => {
     } catch (error) {
       finish(fallbackResponse);
     }
+  });
+});
+
+ipcMain.handle('run-ifs', async (_event, payload) => {
+  if (!lastValidatedPath) {
+    return { status: 'error', message: 'Please validate an IFs folder first.' };
+  }
+
+  const desiredEndYear = Number(payload?.end_year ?? 2050);
+  if (!Number.isFinite(desiredEndYear) || desiredEndYear <= 0) {
+    return { status: 'error', message: 'Invalid end year provided.' };
+  }
+
+  const scriptPath = path.join(__dirname, '..', 'backend', 'run_ifs.py');
+  const progressPath = path.join(lastValidatedPath, 'RUNFILES', 'progress.txt');
+  const args = [
+    scriptPath,
+    '--ifs-root',
+    lastValidatedPath,
+    '--end-year',
+    String(desiredEndYear),
+    '--start-token',
+    '5',
+    '--log',
+    'jrs.txt',
+    '--websessionid',
+    'qsdqsqsdqsdqsdqs',
+  ];
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    let pollTimer = null;
+    let lastYear = null;
+
+    const finish = (payload) => {
+      if (!resolved) {
+        resolved = true;
+        if (pollTimer) {
+          clearInterval(pollTimer);
+          pollTimer = null;
+        }
+        resolve(payload);
+      }
+    };
+
+    const fallback = (message) => ({ status: 'error', message });
+
+    let pythonProcess;
+    try {
+      pythonProcess = spawn('python', args, {
+        cwd: path.join(__dirname, '..'),
+        windowsHide: true,
+      });
+    } catch (error) {
+      finish(fallback('Unable to launch the IFs runner.'));
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+
+    const sendProgress = (year) => {
+      if (lastYear === year) {
+        return;
+      }
+      lastYear = year;
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('ifs-progress', year);
+      }
+    };
+
+    const pollProgress = () => {
+      fs.promises
+        .readFile(progressPath, 'utf8')
+        .then((content) => {
+          const trimmed = content.trim();
+          if (!trimmed) {
+            return;
+          }
+
+          const lines = trimmed.split(/\r?\n/);
+          const lastLine = lines[lines.length - 1];
+          if (!lastLine) {
+            return;
+          }
+
+          const [yearToken] = lastLine.trim().split(/\s+/);
+          const year = Number(yearToken);
+          if (Number.isFinite(year)) {
+            sendProgress(year);
+          }
+        })
+        .catch(() => {
+          // progress file might not exist yet; ignore errors
+        });
+    };
+
+    pythonProcess.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    pythonProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    pythonProcess.on('error', (error) => {
+      finish(fallback(error?.message || 'Failed to execute IFs.'));
+    });
+
+    pollTimer = setInterval(pollProgress, 1000);
+    pollProgress();
+
+    pythonProcess.on('close', (code) => {
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+
+      if (stderr.trim()) {
+        finish(fallback('IFs runner reported an error.'));
+        return;
+      }
+
+      if (code !== 0 && stdout.trim().length === 0) {
+        finish(fallback('IFs runner exited unexpectedly.'));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout || '{}');
+        if (parsed && parsed.status === 'ok') {
+          if (typeof parsed.end_year === 'number') {
+            sendProgress(parsed.end_year);
+          }
+          finish(parsed);
+          return;
+        }
+
+        if (parsed && parsed.status === 'error') {
+          finish(parsed);
+          return;
+        }
+
+        finish(fallback('Unexpected IFs runner response.'));
+      } catch (error) {
+        finish(fallback('Unable to parse IFs runner response.'));
+      }
+    });
   });
 });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -3,4 +3,15 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electron', {
   selectFolder: async () => ipcRenderer.invoke('dialog:selectFolder'),
   invoke: (channel, data) => ipcRenderer.invoke(channel, data),
+  on: (channel, callback) => {
+    const subscription = (_event, ...args) => {
+      callback(...args);
+    };
+
+    ipcRenderer.on(channel, subscription);
+
+    return () => {
+      ipcRenderer.removeListener(channel, subscription);
+    };
+  },
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,169 @@
-import { ChangeEvent, FormEvent, useMemo, useState } from "react";
-import { validateIFsFolder, type CheckResponse } from "./api";
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  runIFs,
+  subscribeToIFsProgress,
+  validateIFsFolder,
+  type CheckResponse,
+  type RunIFsSuccess,
+} from "./api";
+
+type View = "validate" | "tune";
+
+type TuneIFsPageProps = {
+  onBack: () => void;
+  validatedPath: string;
+  baseYear?: number | null;
+};
+
+function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
+  const [endYearInput, setEndYearInput] = useState("2050");
+  const [running, setRunning] = useState(false);
+  const [progressYear, setProgressYear] = useState<number | null>(null);
+  const [metadata, setMetadata] = useState<RunIFsSuccess | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToIFsProgress((year) => {
+      setProgressYear(year);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const handleEndYearChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setEndYearInput(event.target.value);
+  };
+
+  const handleRunClick = async () => {
+    setError(null);
+    setMetadata(null);
+    setProgressYear(null);
+
+    const parsedEndYear = Number(endYearInput);
+    if (!Number.isFinite(parsedEndYear) || parsedEndYear <= 0) {
+      setError("Please enter a valid end year.");
+      return;
+    }
+
+    setRunning(true);
+
+    const response = await runIFs(parsedEndYear);
+    if (response.status === "ok") {
+      setMetadata(response);
+      setProgressYear(response.end_year);
+    } else {
+      setError(response.message);
+    }
+
+    setRunning(false);
+  };
+
+  const numericEndYear = Number(endYearInput);
+  const progressMax =
+    Number.isFinite(numericEndYear) && numericEndYear > 0
+      ? numericEndYear
+      : undefined;
+  const isRunDisabled = running || !progressMax;
+
+  const progressLabel = running
+    ? progressYear != null
+      ? `Current simulation year: ${progressYear}`
+      : "Starting IFs run..."
+    : progressYear != null
+    ? `Last reported year: ${progressYear}`
+    : "Waiting to start.";
+
+  return (
+    <section className="tune-container">
+      <div className="tune-header">
+        <h2>Tune IFs</h2>
+        <p className="tune-description">
+          Launch an IFs simulation and monitor its progress in real time.
+        </p>
+        <p className="tune-path">
+          <span className="label">Validated folder:</span> {validatedPath || "Unknown"}
+        </p>
+        {baseYear != null && (
+          <p className="tune-base">Base year detected: {baseYear}</p>
+        )}
+      </div>
+
+      <div className="tune-controls">
+        <label className="label" htmlFor="end-year-input">
+          End Year
+        </label>
+        <input
+          id="end-year-input"
+          type="number"
+          className="path-input"
+          value={endYearInput}
+          onChange={handleEndYearChange}
+          disabled={running}
+          min={baseYear ?? undefined}
+        />
+        <button
+          type="button"
+          className="button"
+          onClick={handleRunClick}
+          disabled={isRunDisabled}
+        >
+          {running ? "Running..." : "Run IFs"}
+        </button>
+      </div>
+
+      <div className="progress-wrapper">
+        <div className="progress-text">{progressLabel}</div>
+        <progress
+          className="progress-indicator"
+          max={progressMax}
+          value={progressYear ?? undefined}
+        />
+      </div>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {metadata && (
+        <div className="metadata">
+          <h3>Run Metadata</h3>
+          <ul>
+            <li>
+              <strong>Status:</strong> {metadata.status}
+            </li>
+            <li>
+              <strong>End year:</strong> {metadata.end_year}
+            </li>
+            <li>
+              <strong>Log file:</strong> {metadata.log}
+            </li>
+            <li>
+              <strong>Session ID:</strong> {metadata.session_id}
+            </li>
+          </ul>
+        </div>
+      )}
+
+      <div className="tune-footer">
+        <button
+          type="button"
+          className="button secondary"
+          onClick={onBack}
+          disabled={running}
+        >
+          Back to Validation
+        </button>
+      </div>
+    </section>
+  );
+}
 
 function App() {
   const [path, setPath] = useState("");
   const [result, setResult] = useState<CheckResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<View>("validate");
 
   const handleBrowseClick = async () => {
     setError(null);
@@ -30,6 +188,7 @@ function App() {
     setPath(event.target.value);
     setResult(null);
     setError(null);
+    setView("validate");
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -60,77 +219,128 @@ function App() {
   return (
     <div className="container">
       <header className="header">
-        <h1>BIGPOPA - IFs Folder Check</h1>
+        <h1>
+          {view === "validate"
+            ? "BIGPOPA - IFs Folder Check"
+            : "BIGPOPA - Tune IFs"}
+        </h1>
         <p className="subtitle">
-          Browse to your IFs installation folder and validate it against the backend API.
+          {view === "validate"
+            ? "Browse to your IFs installation folder and validate it against the backend API."
+            : "Configure and launch IFs runs with live progress tracking."}
         </p>
       </header>
 
-      <form className="form" onSubmit={handleSubmit}>
-        <label className="label">IFs folder</label>
-        <div className="input-row">
-          <button type="button" className="button" onClick={handleBrowseClick}>
-            Browse
-          </button>
-          <div className="actions">
-            <input
-              type="text"
-              className="path-input"
-              placeholder="Enter or paste a folder path"
-              value={path}
-              onChange={handlePathInputChange}
-              spellCheck={false}
-            />
-            <button type="submit" className="button" disabled={loading}>
-              {loading ? "Validating..." : "Validate"}
+      {view === "validate" && (
+        <>
+          <form className="form" onSubmit={handleSubmit}>
+            <label className="label">IFs folder</label>
+            <div className="input-row">
+              <button
+                type="button"
+                className="button"
+                onClick={handleBrowseClick}
+              >
+                Browse
+              </button>
+              <div className="actions">
+                <input
+                  type="text"
+                  className="path-input"
+                  placeholder="Enter or paste a folder path"
+                  value={path}
+                  onChange={handlePathInputChange}
+                  spellCheck={false}
+                />
+                <button type="submit" className="button" disabled={loading}>
+                  {loading ? "Validating..." : "Validate"}
+                </button>
+              </div>
+            </div>
+          </form>
+
+          {error && <div className="alert alert-error">{error}</div>}
+
+          {result && (
+            <section className="results">
+              <h2>Validation Results</h2>
+              <div className={result.valid ? "status success" : "status error"}>
+                {result.valid ? "Valid ✅" : "Invalid ❌"}
+              </div>
+              {result.base_year != null && (
+                <div className="base-year">Base year: {result.base_year}</div>
+              )}
+
+              {requirements.length > 0 && (
+                <div className="requirements">
+                  <h3>Required files &amp; folders</h3>
+                  <ul>
+                    {requirements.map((item) => (
+                      <li
+                        key={item.file}
+                        className={item.exists ? "item success" : "item error"}
+                      >
+                        <span className="icon">{item.exists ? "✅" : "❌"}</span>
+                        <span>{item.file}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {missingFiles.length > 0 && (
+                <div className="requirements">
+                  <h3>Missing files</h3>
+                  <ul>
+                    {missingFiles.map((file) => (
+                      <li key={file} className="item error">
+                        <span className="icon">❌</span>
+                        <span>{file}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="view-actions">
+                <button
+                  type="button"
+                  className="button secondary"
+                  onClick={() => setView("tune")}
+                  disabled={!result.valid}
+                >
+                  Tune IFs
+                </button>
+              </div>
+            </section>
+          )}
+        </>
+      )}
+
+      {view === "tune" && result?.valid && (
+        <TuneIFsPage
+          onBack={() => setView("validate")}
+          validatedPath={path.trim()}
+          baseYear={result?.base_year}
+        />
+      )}
+
+      {view === "tune" && !result?.valid && (
+        <div className="alert alert-error">
+          <p className="alert-message">
+            Validation is required before tuning IFs. Please return to the
+            validation page.
+          </p>
+          <div className="alert-actions">
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => setView("validate")}
+            >
+              Back to Validation
             </button>
           </div>
         </div>
-      </form>
-
-      {error && <div className="alert alert-error">{error}</div>}
-
-      {result && (
-        <section className="results">
-          <h2>Validation Results</h2>
-          <div className={result.valid ? "status success" : "status error"}>
-            {result.valid ? "Valid ✅" : "Invalid ❌"}
-          </div>
-          {result.base_year != null && (
-            <div className="base-year">Base year: {result.base_year}</div>
-          )}
-
-          {requirements.length > 0 && (
-            <div className="requirements">
-              <h3>Required files &amp; folders</h3>
-              <ul>
-                {requirements.map((item) => (
-                  <li
-                    key={item.file}
-                    className={item.exists ? "item success" : "item error"}
-                  >
-                    <span className="icon">{item.exists ? "✅" : "❌"}</span>
-                    <span>{item.file}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {missingFiles.length > 0 && (
-            <div className="requirements">
-              <h3>Missing files</h3>
-              <ul>
-                {missingFiles.map((file) => (
-                  <li key={file} className="item error">
-                    <span className="icon">❌</span>
-                    <span>{file}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </section>
       )}
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,20 @@ export type CheckResponse = {
   missingFiles?: string[];
 };
 
+export type RunIFsSuccess = {
+  status: "ok";
+  end_year: number;
+  log: string;
+  session_id: string;
+};
+
+export type RunIFsError = {
+  status: "error";
+  message: string;
+};
+
+export type RunIFsResponse = RunIFsSuccess | RunIFsError;
+
 const FALLBACK_RESPONSE: CheckResponse = {
   valid: false,
   base_year: null,
@@ -31,4 +45,52 @@ export async function validateIFsFolder(folderPath: string): Promise<CheckRespon
   } catch (error) {
     return { ...FALLBACK_RESPONSE };
   }
+}
+
+export async function runIFs(endYear: number): Promise<RunIFsResponse> {
+  if (!window.electron?.invoke) {
+    return {
+      status: "error",
+      message: "Electron bridge is unavailable.",
+    };
+  }
+
+  try {
+    const payload = await window.electron.invoke("run-ifs", { end_year: endYear });
+    if (payload && typeof payload === "object" && "status" in payload) {
+      const typed = payload as RunIFsResponse;
+      if (typed.status === "ok") {
+        return typed;
+      }
+
+      if (typed.status === "error") {
+        return typed;
+      }
+    }
+
+    return {
+      status: "error",
+      message: "Unexpected response from IFs runner.",
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to start the IFs run.";
+    return { status: "error", message };
+  }
+}
+
+export function subscribeToIFsProgress(
+  callback: (year: number) => void,
+): () => void {
+  if (!window.electron?.on) {
+    return () => undefined;
+  }
+
+  const handler = (value: unknown) => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      callback(value);
+    }
+  };
+
+  return window.electron.on("ifs-progress", handler);
 }

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -5,6 +5,10 @@ declare global {
     electron?: {
       selectFolder: () => Promise<string | null>;
       invoke: <T = unknown, R = unknown>(channel: string, data?: T) => Promise<R>;
+      on: (
+        channel: string,
+        listener: (...args: unknown[]) => void,
+      ) => () => void;
     };
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -137,6 +137,15 @@ body {
   box-shadow: 0 10px 20px rgba(118, 75, 162, 0.25);
 }
 
+.button.secondary {
+  background: linear-gradient(135deg, #e2e8f0 0%, #cbd5f5 100%);
+  color: #1a202c;
+}
+
+.button.secondary:not(:disabled):hover {
+  box-shadow: 0 10px 20px rgba(148, 163, 184, 0.25);
+}
+
 .alert {
   margin-top: 1.5rem;
   padding: 1rem 1.25rem;
@@ -148,6 +157,15 @@ body {
   background: rgba(245, 101, 101, 0.15);
   color: #c53030;
   border: 1px solid rgba(245, 101, 101, 0.3);
+}
+
+.alert-message {
+  margin: 0 0 0.75rem;
+}
+
+.alert-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .results {
@@ -226,6 +244,113 @@ body {
 .requirements .icon {
   font-size: 1.1rem;
   line-height: 1;
+}
+
+.view-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tune-container {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 12px 30px rgba(72, 89, 241, 0.12);
+  border: 1px solid rgba(72, 84, 96, 0.08);
+}
+
+.tune-header h2 {
+  margin: 0;
+}
+
+.tune-description {
+  color: #4a5568;
+  margin: 0.5rem 0 1rem;
+}
+
+.tune-path,
+.tune-base {
+  color: #2d3748;
+  font-weight: 500;
+  margin: 0.25rem 0;
+}
+
+.tune-controls {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.progress-wrapper {
+  margin-top: 1.5rem;
+  background: #f7fafc;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(203, 213, 224, 0.6);
+}
+
+.progress-text {
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 0.75rem;
+}
+
+.progress-indicator {
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 9999px;
+  background-color: #e2e8f0;
+  overflow: hidden;
+}
+
+.progress-indicator::-webkit-progress-bar {
+  background-color: #e2e8f0;
+  border-radius: 9999px;
+}
+
+.progress-indicator::-webkit-progress-value {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 9999px;
+}
+
+.progress-indicator::-moz-progress-bar {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 9999px;
+}
+
+.metadata {
+  margin-top: 1.5rem;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(203, 213, 224, 0.7);
+}
+
+.metadata h3 {
+  margin: 0 0 0.75rem;
+}
+
+.metadata ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.metadata li {
+  color: #2d3748;
+}
+
+.metadata strong {
+  color: #1a202c;
+}
+
+.tune-footer {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: flex-end;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add a Tune IFs workflow to the frontend with navigation, end year input, and real-time progress display
- expose new IPC helpers in the renderer and preload, and implement a desktop handler that streams progress updates
- provide a Python helper script for launching IFs runs and returning metadata to the UI

## Testing
- npm run build
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68d1ab0438f883278518f944700c5ae8