### PR TITLE
Update validation layout and IFs runner defaults

### DIFF
--- a/backend/run_ifs.py
+++ b/backend/run_ifs.py
@@ -40,7 +40,7 @@ def build_command(args: argparse.Namespace) -> List[str]:
         "-1",
         "true",
         "true",
-        "0",
+        "1",
         "false",
         "--log",
         args.log,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const isDev = !app.isPackaged;
+const STATIC_IFS_ARGS = ['-1', 'true', 'true', '1', 'false'];
 let mainWindow = null;
 let lastValidatedPath = null;
 
@@ -154,6 +155,21 @@ ipcMain.handle('run-ifs', async (_event, payload) => {
     '--websessionid',
     'qsdqsqsdqsdqsdqs',
   ];
+
+  if (isDev) {
+    const ifsExecutable = path.join(lastValidatedPath, 'net8', 'ifs.exe');
+    const commandPreview = [
+      ifsExecutable,
+      '5',
+      String(desiredEndYear),
+      ...STATIC_IFS_ARGS,
+      '--log',
+      'jrs.txt',
+      '--websessionid',
+      'qsdqsqsdqsdqsdqs',
+    ];
+    console.log('Launching IFs via runner with command:', commandPreview.join(' '));
+  }
 
   return new Promise((resolve) => {
     let resolved = false;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -215,6 +215,7 @@ function App() {
 
   const missingFiles = useMemo(() => result?.missingFiles ?? [], [result]);
   const requirements = useMemo(() => result?.requirements ?? [], [result]);
+  const hasValidResult = result?.valid === true;
 
   return (
     <div className="container">
@@ -243,19 +244,32 @@ function App() {
               >
                 Browse
               </button>
-              <div className="actions">
-                <input
-                  type="text"
-                  className="path-input"
-                  placeholder="Enter or paste a folder path"
-                  value={path}
-                  onChange={handlePathInputChange}
-                  spellCheck={false}
-                />
-                <button type="submit" className="button" disabled={loading}>
-                  {loading ? "Validating..." : "Validate"}
-                </button>
-              </div>
+              <input
+                type="text"
+                className="path-input"
+                placeholder="Enter or paste a folder path"
+                value={path}
+                onChange={handlePathInputChange}
+                spellCheck={false}
+              />
+            </div>
+            <div className="button-row">
+              <button type="submit" className="button">
+                {loading ? "Validating..." : "Validate"}
+              </button>
+            </div>
+            <div className="button-row multi">
+              <button
+                type="button"
+                className="button"
+                onClick={() => setView("tune")}
+                disabled={!hasValidResult}
+              >
+                Tune IFs
+              </button>
+              <button type="button" className="button" disabled={!hasValidResult}>
+                Base Year Change
+              </button>
             </div>
           </form>
 
@@ -302,16 +316,6 @@ function App() {
                 </div>
               )}
 
-              <div className="view-actions">
-                <button
-                  type="button"
-                  className="button secondary"
-                  onClick={() => setView("tune")}
-                  disabled={!result.valid}
-                >
-                  Tune IFs
-                </button>
-              </div>
             </section>
           )}
         </>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -49,7 +49,11 @@ body {
 .input-row {
   display: flex;
   gap: 1rem;
-  align-items: flex-start;
+  align-items: center;
+}
+
+.input-row .path-input {
+  flex: 1;
 }
 
 .file-picker {
@@ -77,13 +81,6 @@ body {
   inset: 0;
   opacity: 0;
   cursor: pointer;
-}
-
-.actions {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
 }
 
 .path-input {
@@ -144,6 +141,21 @@ body {
 
 .button.secondary:not(:disabled):hover {
   box-shadow: 0 10px 20px rgba(148, 163, 184, 0.25);
+}
+
+.button-row {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.button-row .button {
+  width: 100%;
+}
+
+.button-row.multi {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
 }
 
 .alert {
@@ -244,12 +256,6 @@ body {
 .requirements .icon {
   font-size: 1.1rem;
   line-height: 1;
-}
-
-.view-actions {
-  margin-top: 1.5rem;
-  display: flex;
-  justify-content: flex-end;
 }
 
 .tune-container {


### PR DESCRIPTION
## Summary
- restructure the validation form so Validate, Tune IFs, and Base Year Change occupy dedicated button rows with shared styling and conditional enablement
- adjust styles to support the new layout while keeping the existing visual theme consistent
- change the IFs runner defaults to use the updated `-1 true true 1 false` argument set and surface a dev-time preview of the command

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b6eb735483279c12ef4b462e4a84