### PR TITLE
Stream IFs output and expose WGDP results

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,10 +135,10 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
               <strong>End year:</strong> {metadata.end_year}
             </li>
             <li>
-              <strong>Log file:</strong> {metadata.log}
-            </li>
-            <li>
-              <strong>Session ID:</strong> {metadata.session_id}
+              <strong>World GDP (WGDP):</strong>{' '}
+              {metadata.w_gdp.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+              })}
             </li>
           </ul>
         </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,10 +11,9 @@ export type CheckResponse = {
 };
 
 export type RunIFsSuccess = {
-  status: "ok";
+  status: "success";
   end_year: number;
-  log: string;
-  session_id: string;
+  w_gdp: number;
 };
 
 export type RunIFsError = {
@@ -59,7 +58,7 @@ export async function runIFs(endYear: number): Promise<RunIFsResponse> {
     const payload = await window.electron.invoke("run-ifs", { end_year: endYear });
     if (payload && typeof payload === "object" && "status" in payload) {
       const typed = payload as RunIFsResponse;
-      if (typed.status === "ok") {
+      if (typed.status === "success") {
         return typed;
       }
 


### PR DESCRIPTION
## Summary
- stream IFs execution in `run_ifs.py`, forwarding stdout for live progress and parsing `progress.txt` for the final year and WGDP
- update the Electron `run-ifs` handler to consume streamed progress lines and expect the new success payload shape
- adjust the frontend API types and metadata view to surface the returned WGDP value

## Testing
- `pytest -q` *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c6d3195c83279c909c484784dace