### PR TITLE
Enhance Tune IFs workflow with output artifacts and modal run controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,30 +1,183 @@
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   runIFs,
   subscribeToIFsProgress,
   validateIFsFolder,
   type CheckResponse,
+  type IFsProgressEvent,
   type RunIFsSuccess,
 } from "./api";
 
 type View = "validate" | "tune";
 
+type RunConfigModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  endYearInput: string;
+  onEndYearChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  running: boolean;
+  baseYear: number | null;
+};
+
 type TuneIFsPageProps = {
   onBack: () => void;
   validatedPath: string;
   baseYear?: number | null;
+  outputDirectory: string | null;
+  requestOutputDirectory: () => Promise<string | null>;
+  runModalTrigger: number;
 };
 
-function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
+function calculateProgressPercentage(
+  currentYear: number,
+  baseYear: number | null | undefined,
+  endYear: number | null | undefined,
+): number | null {
+  if (!Number.isFinite(currentYear)) {
+    return null;
+  }
+
+  if (typeof baseYear !== "number" || !Number.isFinite(baseYear)) {
+    return null;
+  }
+
+  if (typeof endYear !== "number" || !Number.isFinite(endYear)) {
+    return null;
+  }
+
+  if (endYear === baseYear) {
+    return currentYear >= endYear ? 100 : 0;
+  }
+
+  const percentage = ((currentYear - baseYear) / (endYear - baseYear)) * 100;
+  const clamped = Math.min(100, Math.max(0, percentage));
+  return clamped;
+}
+
+function RunConfigModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  endYearInput,
+  onEndYearChange,
+  running,
+  baseYear,
+}: RunConfigModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-content">
+        <h3 className="modal-title">Configure IFs Run</h3>
+        <p className="modal-subtitle">
+          Select the target end year and launch the simulation.
+        </p>
+        <p className="modal-base-year">
+          <strong>Base year:</strong>{" "}
+          {typeof baseYear === "number" && Number.isFinite(baseYear)
+            ? baseYear
+            : "Unknown"}
+        </p>
+        <label className="label" htmlFor="modal-end-year">
+          End Year
+        </label>
+        <input
+          id="modal-end-year"
+          type="number"
+          className="path-input"
+          value={endYearInput}
+          onChange={onEndYearChange}
+          disabled={running}
+          min={baseYear ?? undefined}
+        />
+        <div className="modal-actions">
+          <button
+            type="button"
+            className="button secondary"
+            onClick={onClose}
+            disabled={running}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="button"
+            onClick={onSubmit}
+            disabled={running}
+          >
+            {running ? "Running..." : "Run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TuneIFsPage({
+  onBack,
+  validatedPath,
+  baseYear,
+  outputDirectory,
+  requestOutputDirectory,
+  runModalTrigger,
+}: TuneIFsPageProps) {
   const [endYearInput, setEndYearInput] = useState("2050");
   const [running, setRunning] = useState(false);
   const [progressYear, setProgressYear] = useState<number | null>(null);
+  const [progressPercent, setProgressPercent] = useState(0);
   const [metadata, setMetadata] = useState<RunIFsSuccess | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showRunModal, setShowRunModal] = useState(false);
+  const [lastModalTrigger, setLastModalTrigger] = useState<number | null>(null);
+  const baseYearRef = useRef<number | null>(baseYear ?? null);
+  const targetEndYearRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const unsubscribe = subscribeToIFsProgress((year) => {
-      setProgressYear(year);
+    baseYearRef.current = baseYear ?? null;
+  }, [baseYear]);
+
+  useEffect(() => {
+    if (runModalTrigger && runModalTrigger !== lastModalTrigger) {
+      setShowRunModal(true);
+      setLastModalTrigger(runModalTrigger);
+    }
+  }, [runModalTrigger, lastModalTrigger]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToIFsProgress((event: IFsProgressEvent) => {
+      setProgressYear(event.year);
+
+      setProgressPercent((previous) => {
+        const directPercent =
+          typeof event.percent === "number" && Number.isFinite(event.percent)
+            ? event.percent
+            : null;
+
+        const computedPercent =
+          directPercent ??
+          calculateProgressPercentage(
+            event.year,
+            baseYearRef.current,
+            targetEndYearRef.current,
+          );
+
+        if (computedPercent == null) {
+          return previous;
+        }
+
+        const clamped = Math.min(100, Math.max(0, computedPercent));
+        return Math.max(previous, clamped);
+      });
     });
 
     return () => {
@@ -32,14 +185,47 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
     };
   }, []);
 
+  useEffect(() => {
+    if (metadata && typeof metadata.base_year === "number") {
+      baseYearRef.current = metadata.base_year;
+    }
+  }, [metadata]);
+
   const handleEndYearChange = (event: ChangeEvent<HTMLInputElement>) => {
     setEndYearInput(event.target.value);
   };
 
+  const openRunModal = () => {
+    setShowRunModal(true);
+  };
+
+  const closeRunModal = () => {
+    if (!running) {
+      setShowRunModal(false);
+    }
+  };
+
+  const handleChangeOutputDirectory = async () => {
+    if (running) {
+      return;
+    }
+
+    try {
+      const selected = await requestOutputDirectory();
+      if (selected) {
+        setShowRunModal(true);
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Unable to update the output directory.";
+      setError(message);
+    }
+  };
+
   const handleRunClick = async () => {
     setError(null);
-    setMetadata(null);
-    setProgressYear(null);
 
     const parsedEndYear = Number(endYearInput);
     if (!Number.isFinite(parsedEndYear) || parsedEndYear <= 0) {
@@ -47,12 +233,32 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
       return;
     }
 
-    setRunning(true);
+    if (!outputDirectory) {
+      setError("Please choose an output folder before running IFs.");
+      return;
+    }
 
-    const response = await runIFs(parsedEndYear);
-    if (response.status === "ok") {
+    targetEndYearRef.current = parsedEndYear;
+    setShowRunModal(false);
+    setRunning(true);
+    setMetadata(null);
+    setProgressYear(null);
+    setProgressPercent(0);
+
+    const response = await runIFs({
+      endYear: parsedEndYear,
+      baseYear: baseYearRef.current,
+      outputDirectory,
+    });
+
+    if (response.status === "success") {
       setMetadata(response);
       setProgressYear(response.end_year);
+      setProgressPercent(100);
+      targetEndYearRef.current = response.end_year;
+      if (typeof response.base_year === "number") {
+        baseYearRef.current = response.base_year;
+      }
     } else {
       setError(response.message);
     }
@@ -60,20 +266,21 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
     setRunning(false);
   };
 
-  const numericEndYear = Number(endYearInput);
-  const progressMax =
-    Number.isFinite(numericEndYear) && numericEndYear > 0
-      ? numericEndYear
-      : undefined;
-  const isRunDisabled = running || !progressMax;
+  const displayPercent = Math.min(100, Math.max(0, progressPercent));
+  const formattedPercent = `${displayPercent.toFixed(1)}%`;
 
-  const progressLabel = running
-    ? progressYear != null
-      ? `Current simulation year: ${progressYear}`
-      : "Starting IFs run..."
-    : progressYear != null
-    ? `Last reported year: ${progressYear}`
-    : "Waiting to start.";
+  const progressLabel =
+    progressYear != null
+      ? `Last reported year: ${progressYear} (${formattedPercent})`
+      : running
+      ? "Starting IFs run..."
+      : metadata
+      ? "Run completed."
+      : "Waiting to start.";
+
+  const wgdDisplay = metadata
+    ? metadata.w_gdp.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : "";
 
   return (
     <section className="tune-container">
@@ -85,31 +292,31 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
         <p className="tune-path">
           <span className="label">Validated folder:</span> {validatedPath || "Unknown"}
         </p>
-        {baseYear != null && (
-          <p className="tune-base">Base year detected: {baseYear}</p>
+        {baseYearRef.current != null && (
+          <p className="tune-base">Base year detected: {baseYearRef.current}</p>
         )}
+        <p className="tune-output">
+          <span className="label">Output folder:</span>{" "}
+          {outputDirectory ?? "No folder selected"}
+        </p>
       </div>
 
-      <div className="tune-controls">
-        <label className="label" htmlFor="end-year-input">
-          End Year
-        </label>
-        <input
-          id="end-year-input"
-          type="number"
-          className="path-input"
-          value={endYearInput}
-          onChange={handleEndYearChange}
-          disabled={running}
-          min={baseYear ?? undefined}
-        />
+      <div className="tune-actions">
         <button
           type="button"
           className="button"
-          onClick={handleRunClick}
-          disabled={isRunDisabled}
+          onClick={openRunModal}
+          disabled={running || !outputDirectory}
         >
           {running ? "Running..." : "Run IFs"}
+        </button>
+        <button
+          type="button"
+          className="button secondary"
+          onClick={handleChangeOutputDirectory}
+          disabled={running}
+        >
+          Change output folder
         </button>
       </div>
 
@@ -117,8 +324,8 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
         <div className="progress-text">{progressLabel}</div>
         <progress
           className="progress-indicator"
-          max={progressMax}
-          value={progressYear ?? undefined}
+          max={100}
+          value={displayPercent}
         />
       </div>
 
@@ -126,19 +333,26 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
 
       {metadata && (
         <div className="metadata">
-          <h3>Run Metadata</h3>
+          <div className="run-status success">Run successful</div>
           <ul>
             <li>
-              <strong>Status:</strong> {metadata.status}
+              <strong>Model ID:</strong> {metadata.model_id}
+            </li>
+            <li>
+              <strong>Base year:</strong>{" "}
+              {metadata.base_year != null ? metadata.base_year : "Unknown"}
             </li>
             <li>
               <strong>End year:</strong> {metadata.end_year}
             </li>
             <li>
-              <strong>World GDP (WGDP):</strong>{' '}
-              {metadata.w_gdp.toLocaleString(undefined, {
-                maximumFractionDigits: 2,
-              })}
+              <strong>World GDP (WGDP):</strong> {wgdDisplay}
+            </li>
+            <li>
+              <strong>Saved file:</strong> {metadata.output_file}
+            </li>
+            <li>
+              <strong>Metadata file:</strong> {metadata.metadata_file}
             </li>
           </ul>
         </div>
@@ -154,6 +368,16 @@ function TuneIFsPage({ onBack, validatedPath, baseYear }: TuneIFsPageProps) {
           Back to Validation
         </button>
       </div>
+
+      <RunConfigModal
+        isOpen={showRunModal}
+        onClose={closeRunModal}
+        onSubmit={handleRunClick}
+        endYearInput={endYearInput}
+        onEndYearChange={handleEndYearChange}
+        running={running}
+        baseYear={baseYearRef.current}
+      />
     </section>
   );
 }
@@ -164,6 +388,8 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<View>("validate");
+  const [outputDirectory, setOutputDirectory] = useState<string | null>(null);
+  const [runModalTrigger, setRunModalTrigger] = useState(0);
 
   const handleBrowseClick = async () => {
     setError(null);
@@ -178,6 +404,7 @@ function App() {
       if (selectedPath) {
         setPath(selectedPath);
         setResult(null);
+        setView("validate");
       }
     } catch (err) {
       setError("Unable to open the folder picker. Please try again.");
@@ -210,6 +437,41 @@ function App() {
       setError("Failed to validate the IFs folder. Please try again.");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const requestOutputDirectory = async () => {
+    if (!window.electron?.selectFolder) {
+      throw new Error("Native folder browsing is only available in the desktop app.");
+    }
+
+    try {
+      const selected = await window.electron.selectFolder();
+      if (selected) {
+        setOutputDirectory(selected);
+        return selected;
+      }
+      return null;
+    } catch (err) {
+      throw new Error("Unable to open the folder picker. Please try again.");
+    }
+  };
+
+  const handleTuneClick = async () => {
+    setError(null);
+
+    try {
+      const selected = await requestOutputDirectory();
+      if (selected) {
+        setView("tune");
+        setRunModalTrigger((prev) => prev + 1);
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Unable to open the folder picker. Please try again.";
+      setError(message);
     }
   };
 
@@ -262,7 +524,7 @@ function App() {
               <button
                 type="button"
                 className="button"
-                onClick={() => setView("tune")}
+                onClick={handleTuneClick}
                 disabled={!hasValidResult}
               >
                 Tune IFs
@@ -315,7 +577,6 @@ function App() {
                   </ul>
                 </div>
               )}
-
             </section>
           )}
         </>
@@ -326,6 +587,9 @@ function App() {
           onBack={() => setView("validate")}
           validatedPath={path.trim()}
           baseYear={result?.base_year}
+          outputDirectory={outputDirectory}
+          requestOutputDirectory={requestOutputDirectory}
+          runModalTrigger={runModalTrigger}
         />
       )}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -282,8 +282,28 @@ body {
   margin: 0.25rem 0;
 }
 
+.tune-path .label,
+.tune-output .label {
+  display: inline;
+  margin-right: 0.35rem;
+}
+
+.tune-output {
+  color: #2d3748;
+  font-weight: 500;
+  margin: 0.25rem 0 0;
+  word-break: break-word;
+}
+
 .tune-controls {
   display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.tune-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
   margin-top: 1.5rem;
 }
@@ -353,10 +373,64 @@ body {
   color: #1a202c;
 }
 
+.run-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  background: rgba(72, 187, 120, 0.15);
+  color: #276749;
+  margin-bottom: 0.75rem;
+}
+
 .tune-footer {
   margin-top: 2rem;
   display: flex;
   justify-content: flex-end;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  width: min(480px, 100%);
+  box-shadow: 0 20px 45px rgba(60, 66, 87, 0.3);
+  border: 1px solid rgba(72, 84, 96, 0.12);
+}
+
+.modal-title {
+  margin: 0;
+}
+
+.modal-subtitle {
+  margin: 0.75rem 0 1.25rem;
+  color: #4a5568;
+}
+
+.modal-base-year {
+  margin: 0 0 1rem;
+  color: #2d3748;
+  font-weight: 500;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
 }
 
 @media (max-width: 600px) {
@@ -380,5 +454,9 @@ body {
 
   .button {
     width: 100%;
+  }
+
+  .tune-actions {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add a run configuration modal, output directory selection, progress feedback, and metadata presentation to the Tune IFs page
- stream structured IFs progress (year and percentage) from the Electron bridge while validating output folders and persisting base year context
- extend the Python IFs runner to copy Working.run.db into the chosen folder, emit JSON metadata files, and return enriched run results

## Testing
- npm run build
- pytest backend *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68d1d51feb54832791c34e3515650bb6