### PR TITLE
Improve folder selection UX for web builds

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -171,6 +171,12 @@ body {
   border: 1px solid rgba(245, 101, 101, 0.3);
 }
 
+.alert-info {
+  background: rgba(66, 153, 225, 0.15);
+  color: #2b6cb0;
+  border: 1px solid rgba(66, 153, 225, 0.3);
+}
+
 .alert-message {
   margin: 0 0 0.75rem;
 }


### PR DESCRIPTION
## Summary
- add fallback messaging and focus behaviour when native folder browsing is unavailable so users can paste folder paths manually
- allow manual editing of the output folder when no native picker is present and realign the form so buttons appear on the left of their inputs
- style a new informational alert to display desktop-app guidance without surfacing an error state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3205cbdc88327b6c908d2b2d73b4f