### PR TITLE
Fix Electron folder picker exposure

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -48,7 +48,7 @@ app.on('window-all-closed', () => {
   }
 });
 
-ipcMain.handle('dialog:selectFolder', async () => {
+ipcMain.handle('select-folder', async () => {
   const { canceled, filePaths } = await dialog.showOpenDialog({
     properties: ['openDirectory'],
   });
@@ -58,6 +58,10 @@ ipcMain.handle('dialog:selectFolder', async () => {
   }
 
   return filePaths[0];
+});
+
+ipcMain.handle('get-default-output-dir', async () => {
+  return path.join(app.getPath('documents'), 'IFs_Output');
 });
 
 ipcMain.handle('validate-ifs-folder', async (_event, folderPath) => {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,9 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const { app } = require('electron');
-const path = require('path');
 
 contextBridge.exposeInMainWorld('electron', {
-  selectFolder: async () => ipcRenderer.invoke('dialog:selectFolder'),
+  selectFolder: () => ipcRenderer.invoke('select-folder'),
   invoke: (channel, data) => ipcRenderer.invoke(channel, data),
   on: (channel, callback) => {
     const subscription = (_event, ...args) => {
@@ -16,7 +14,5 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.removeListener(channel, subscription);
     };
   },
-  getDefaultOutputDir: () => {
-    return path.join(app.getPath('documents'), 'IFs_Output');
-  },
+  getDefaultOutputDir: () => ipcRenderer.invoke('get-default-output-dir'),
 });

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -9,7 +9,7 @@ declare global {
         channel: string,
         listener: (...args: unknown[]) => void,
       ) => () => void;
-      getDefaultOutputDir: () => string;
+      getDefaultOutputDir: () => Promise<string>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- update the Electron main process to expose select-folder and default output directory IPC handlers
- expose the folder selection and default output directory helpers from the preload script using the new IPC channels
- fetch the default output directory asynchronously in the React app and update the window typings accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3276348908327b4b5ca853b7d2f00