### PR TITLE
Improve folder selection UX and defaults

### DIFF
--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,7 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electron', {
-  selectFolder: () => ipcRenderer.invoke('select-folder'),
+  selectFolder: (type, defaultPath) =>
+    ipcRenderer.invoke('select-folder', { type, defaultPath }),
+  getDefaultOutputDir: () => ipcRenderer.invoke('get-default-output-dir'),
   invoke: (channel, data) => ipcRenderer.invoke(channel, data),
   on: (channel, callback) => {
     const subscription = (_event, ...args) => {
@@ -14,5 +16,4 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.removeListener(channel, subscription);
     };
   },
-  getDefaultOutputDir: () => ipcRenderer.invoke('get-default-output-dir'),
 });

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -3,13 +3,16 @@ export {};
 declare global {
   interface Window {
     electron?: {
-      selectFolder: () => Promise<string | null>;
+      selectFolder: (
+        type: 'ifs' | 'output',
+        defaultPath?: string | null,
+      ) => Promise<string | null>;
+      getDefaultOutputDir: () => Promise<string>;
       invoke: <T = unknown, R = unknown>(channel: string, data?: T) => Promise<R>;
       on: (
         channel: string,
         listener: (...args: unknown[]) => void,
       ) => () => void;
-      getDefaultOutputDir: () => Promise<string>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- refresh the validation UI to manage IFs/output folder paths via dedicated state and updated buttons
- expose a typed folder selection bridge and main-process handler that honors defaults and creates the output directory when needed
- ensure the renderer requests independent folder selections and loads the default ./output location

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d419f746988327b04a660a2c1faeea