### PR TITLE
Improve folder path inputs and validation reset

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -48,12 +48,15 @@ body {
 
 .input-row {
   display: flex;
-  gap: 1rem;
   align-items: center;
+  margin-bottom: 1rem;
 }
 
-.input-row .path-input {
-  flex: 1;
+.input-row .button {
+  min-width: 180px;
+  margin-right: 10px;
+  background: linear-gradient(90deg, #6a5acd, #7b68ee);
+  color: white;
 }
 
 .file-picker {
@@ -84,11 +87,11 @@ body {
 }
 
 .path-input {
+  flex: 1;
   width: 100%;
-  min-height: 3rem;
-  padding: 0.75rem 1rem;
-  border: 1px dashed #cbd5e0;
-  border-radius: 0.75rem;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
   background: #f7fafc;
   color: #2d3748;
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- align the IFs and output folder selectors with consistent button styling
- allow manual entry of folder paths while tracking the last validated IFs directory
- reset validation results when the IFs path changes and disable actions until revalidated

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d4356f8a0883279556ae9d077068aa