### PR TITLE
Add input Excel validation to BIGPOPA desktop flow

### DIFF
--- a/backend/app/ifscheck.py
+++ b/backend/app/ifscheck.py
@@ -1,6 +1,8 @@
 import os
 import sqlite3
-from typing import Optional
+import zipfile
+from typing import Dict, Optional
+from xml.etree import ElementTree
 
 from fastapi import APIRouter
 
@@ -13,6 +15,8 @@ REQUIRED_PATHS = [
     "RUNFILES/",
     "Scenario/",
 ]
+
+REQUIRED_INPUT_SHEETS = ["AnalFunc", "TablFunc", "IFsVar", "DataDict"]
 
 
 router = APIRouter()
@@ -43,7 +47,10 @@ def _fetch_year(cur: sqlite3.Cursor, like_pattern: str) -> Optional[int]:
     return _extract_year(row[0])
 
 
-def _path_exists(base_path: str, required_path: str) -> bool:
+def _path_exists(base_path: Optional[str], required_path: str) -> bool:
+    if not base_path:
+        return False
+
     normalized = required_path[:-1] if required_path.endswith("/") else required_path
     absolute = os.path.join(base_path, normalized)
     if required_path.endswith("/"):
@@ -51,41 +58,171 @@ def _path_exists(base_path: str, required_path: str) -> bool:
     return os.path.isfile(absolute)
 
 
-def validate_ifs_folder(path: str) -> dict:
+def _check_directory(
+    raw_path: Optional[str], *, require_writable: bool = False
+) -> Dict[str, object]:
+    provided = (raw_path or "").strip()
+    absolute = os.path.abspath(provided) if provided else None
+    display_path = absolute or (provided or None)
+    exists = False
+    readable = False
+    writable: Optional[bool] = None
+    message: Optional[str] = None
+
+    if not absolute:
+        message = "No path provided."
+    elif not os.path.exists(absolute):
+        message = "Path does not exist."
+    elif not os.path.isdir(absolute):
+        message = "Path is not a directory."
+    else:
+        exists = True
+        readable = os.access(absolute, os.R_OK)
+        if not readable:
+            message = "Directory is not readable."
+
+        if require_writable:
+            writable = os.access(absolute, os.W_OK)
+            if writable is False:
+                message = "Directory is not writable."
+        else:
+            writable = None
+
+    return {
+        "displayPath": display_path,
+        "exists": exists,
+        "readable": readable,
+        "writable": writable,
+        "message": message,
+    }
+
+
+def _check_input_file(raw_path: Optional[str]) -> Dict[str, object]:
+    provided = (raw_path or "").strip()
+    absolute = os.path.abspath(provided) if provided else None
+    display_path = absolute or (provided or None)
+    sheets: Dict[str, bool] = {name: False for name in REQUIRED_INPUT_SHEETS}
+    missing_sheets = list(REQUIRED_INPUT_SHEETS)
+    exists = False
+    readable = False
+    message: Optional[str] = None
+
+    if not absolute:
+        message = "No path provided."
+    elif not os.path.exists(absolute):
+        message = "File does not exist."
+    elif not os.path.isfile(absolute):
+        message = "Path is not a file."
+    elif not os.access(absolute, os.R_OK):
+        exists = True
+        message = "File is not readable."
+    else:
+        exists = True
+        readable = True
+        try:
+            with zipfile.ZipFile(absolute) as archive:
+                with archive.open("xl/workbook.xml") as workbook_xml:
+                    content = workbook_xml.read()
+        except KeyError:
+            readable = False
+            message = "Workbook metadata is missing."
+        except (OSError, zipfile.BadZipFile) as exc:
+            readable = False
+            message = f"Unable to read workbook: {exc}"
+        else:
+            try:
+                tree = ElementTree.fromstring(content)
+            except ElementTree.ParseError as exc:
+                readable = False
+                message = f"Unable to parse workbook metadata: {exc}"
+            else:
+                namespace = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+                for sheet_node in tree.findall(f".//{namespace}sheet"):
+                    name = sheet_node.attrib.get("name")
+                    if name in sheets:
+                        sheets[name] = True
+
+                missing_sheets = [name for name, present in sheets.items() if not present]
+                if missing_sheets:
+                    message = "Missing sheets: " + ", ".join(missing_sheets)
+
+    return {
+        "displayPath": display_path,
+        "exists": exists,
+        "readable": readable,
+        "message": message,
+        "sheets": sheets,
+        "missingSheets": missing_sheets,
+    }
+
+
+def validate_ifs_folder(
+    path: str,
+    output_path: Optional[str] = None,
+    input_file: Optional[str] = None,
+) -> dict:
+    sanitized_path = (path or "").strip()
+    absolute_path = os.path.abspath(sanitized_path) if sanitized_path else None
+
     requirements = []
     for required in REQUIRED_PATHS:
-        exists = _path_exists(path, required)
+        exists = _path_exists(absolute_path, required)
         requirements.append({"file": required, "exists": exists})
 
     base_year: Optional[int] = None
 
-    init_db = os.path.join(path, "IFsInit.db")
-    if os.path.isfile(init_db):
-        try:
-            with sqlite3.connect(init_db) as con:
-                cur = con.cursor()
-                history_year = _fetch_year(cur, "LastYearHistory%")
-                forecast_year = _fetch_year(cur, "FirstYearForecast%")
+    if absolute_path:
+        init_db = os.path.join(absolute_path, "IFsInit.db")
+        if os.path.isfile(init_db):
+            try:
+                with sqlite3.connect(init_db) as con:
+                    cur = con.cursor()
+                    history_year = _fetch_year(cur, "LastYearHistory%")
+                    forecast_year = _fetch_year(cur, "FirstYearForecast%")
 
-            if history_year and forecast_year:
-                # Prefer the last historical year when available; fall back to
-                # the forecast start if it's the only consistent option.
-                if history_year <= forecast_year:
-                    base_year = history_year
+                if history_year and forecast_year:
+                    # Prefer the last historical year when available; fall back to
+                    # the forecast start if it's the only consistent option.
+                    if history_year <= forecast_year:
+                        base_year = history_year
+                    else:
+                        base_year = forecast_year
                 else:
-                    base_year = forecast_year
-            else:
-                base_year = history_year or forecast_year
-        except sqlite3.Error:
-            base_year = None
+                    base_year = history_year or forecast_year
+            except sqlite3.Error:
+                base_year = None
+
+    ifs_folder_check = _check_directory(sanitized_path)
+    if absolute_path:
+        ifs_folder_check["displayPath"] = absolute_path
+
+    output_folder_check = _check_directory(output_path, require_writable=True)
+    input_file_check = _check_input_file(input_file)
+
+    all_requirements_met = all(item["exists"] for item in requirements)
+    output_ready = output_folder_check["exists"] and bool(output_folder_check["writable"])
+    input_ready = (
+        input_file_check["exists"]
+        and input_file_check["readable"]
+        and all(input_file_check["sheets"].get(name, False) for name in REQUIRED_INPUT_SHEETS)
+    )
 
     return {
-        "valid": all(item["exists"] for item in requirements),
+        "valid": all_requirements_met and output_ready and input_ready,
         "requirements": requirements,
         "base_year": base_year,
+        "pathChecks": {
+            "ifsFolder": ifs_folder_check,
+            "outputFolder": output_folder_check,
+            "inputFile": input_file_check,
+        },
     }
 
 
 @router.post("/check")
 def check_folder(payload: dict) -> dict:
-    return validate_ifs_folder(payload["path"])
+    return validate_ifs_folder(
+        payload["path"],
+        output_path=payload.get("outputPath"),
+        input_file=payload.get("inputFile"),
+    )

--- a/backend/validate_ifs.py
+++ b/backend/validate_ifs.py
@@ -8,6 +8,7 @@ stdout.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -36,7 +37,14 @@ except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency shi
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) < 2:
+    parser = argparse.ArgumentParser(description="Validate an IFs installation folder")
+    parser.add_argument("path", nargs="?")
+    parser.add_argument("--output-path", dest="output_path")
+    parser.add_argument("--input-file", dest="input_file")
+
+    args = parser.parse_args(argv[1:])
+
+    if not args.path:
         payload: dict[str, Any] = {
             "valid": False,
             "missingFiles": ["No folder path provided"],
@@ -44,10 +52,12 @@ def main(argv: list[str]) -> int:
         print(json.dumps(payload))
         return 1
 
-    folder_path = argv[1]
-
     try:
-        result = validate_ifs_folder(folder_path)
+        result = validate_ifs_folder(
+            args.path,
+            output_path=args.output_path,
+            input_file=args.input_file,
+        )
     except Exception:  # pragma: no cover - surface any unexpected error
         payload = {"valid": False, "missingFiles": ["Python error"]}
         print(json.dumps(payload))

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -3,6 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electron', {
   selectFolder: (type, defaultPath) =>
     ipcRenderer.invoke('select-folder', { type, defaultPath }),
+  selectFile: (defaultPath) =>
+    ipcRenderer.invoke('select-input-file', { defaultPath }),
   getDefaultOutputDir: () => ipcRenderer.invoke('get-default-output-dir'),
   invoke: (channel, data) => ipcRenderer.invoke(channel, data),
   on: (channel, callback) => {

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -7,6 +7,7 @@ declare global {
         type: 'ifs' | 'output',
         defaultPath?: string | null,
       ) => Promise<string | null>;
+      selectFile: (defaultPath?: string | null) => Promise<string | null>;
       getDefaultOutputDir: () => Promise<string>;
       invoke: <T = unknown, R = unknown>(channel: string, data?: T) => Promise<R>;
       on: (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -230,6 +230,69 @@ body {
   margin-bottom: 1rem;
 }
 
+.summary {
+  margin-bottom: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.summary-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 0.75rem;
+  font-weight: 500;
+}
+
+.summary-line.success {
+  background: rgba(72, 187, 120, 0.12);
+  color: #276749;
+}
+
+.summary-line.error {
+  background: rgba(245, 101, 101, 0.12);
+  color: #c53030;
+}
+
+.summary-label {
+  font-weight: 600;
+}
+
+.summary-value {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  word-break: break-word;
+}
+
+.summary-message {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.sheet-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.sheet-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+.sheet-status.present {
+  color: #276749;
+}
+
+.sheet-status.missing {
+  color: #c53030;
+}
+
 .requirements h3 {
   margin-bottom: 0.75rem;
   color: #2d3748;


### PR DESCRIPTION
## Summary
- add desktop picker and frontend form state for selecting the input Excel file alongside IFs and output folders
- surface backend validation results for IFs folder, output directory, and Excel sheet presence via the existing validation panel
- extend the Python validator and Electron bridge to validate directories and inspect workbook sheets before approving the configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6862c91c8327b7f98fb15ffc9c35