### PR TITLE
Add inline end year controls to IFs tuning page

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -310,6 +310,87 @@ body {
   margin-top: 1.5rem;
 }
 
+.end-year-control {
+  background: #f8fafc;
+  border: 1px solid rgba(203, 213, 224, 0.6);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.end-year-control .label {
+  margin-bottom: 0.5rem;
+}
+
+.end-year-inputs {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .end-year-inputs {
+    grid-template-columns: minmax(0, 200px) 1fr;
+    align-items: center;
+  }
+}
+
+.end-year-number {
+  max-width: 100%;
+}
+
+.end-year-slider {
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: #e2e8f0;
+  outline: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  accent-color: #667eea;
+}
+
+.end-year-slider:hover {
+  background: #d6dcf3;
+}
+
+.end-year-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.end-year-slider::-webkit-slider-runnable-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.end-year-slider::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.end-year-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background: #ffffff;
+  border: 3px solid #4c51bf;
+  box-shadow: 0 3px 6px rgba(79, 70, 229, 0.25);
+  margin-top: -0.25rem;
+}
+
+.end-year-slider::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background: #ffffff;
+  border: 3px solid #4c51bf;
+  box-shadow: 0 3px 6px rgba(79, 70, 229, 0.25);
+}
+
 .tune-actions {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- replace the IFs tuning modal with an inline end year number field and slider
- clamp the end year to the detected base year and update the run request with the selected value
- style the new inline control to match the existing tuning layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6bccd8a083279fdc16ad16844de9