### PR TITLE
Pass validated paths to model setup script

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -565,19 +565,27 @@ ipcMain.handle('run_ifs', async (_event, payload) => {
   return runPythonScript('run_ifs.py', args);
 });
 
-ipcMain.handle('model_setup', async (_event, payload) =>
-  runPythonScript('model_setup.py', [
-    '--payload',
-    JSON.stringify({
-      ifs_root: payload.validatedPath,
-      baseYear: payload.baseYear,
-      endYear: payload.endYear,
-      parameters: payload.parameters,
-      coefficients: payload.coefficients,
-      param_dim_dict: payload.paramDim || {},
-    }),
-  ]),
-);
+ipcMain.handle('model_setup', async (_event, payload) => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid payload for model_setup');
+  }
+
+  const validatedPath =
+    typeof payload.validatedPath === 'string' ? payload.validatedPath.trim() : '';
+  const inputFilePath =
+    typeof payload.inputFilePath === 'string' ? payload.inputFilePath.trim() : '';
+
+  if (!validatedPath) {
+    throw new Error('model_setup requires a validatedPath');
+  }
+
+  if (!inputFilePath) {
+    throw new Error('model_setup requires an inputFilePath');
+  }
+
+  const args = ['--ifs-root', validatedPath, '--input-file', inputFilePath];
+  return runPythonScript('model_setup.py', args);
+});
 
 ipcMain.handle('validate_ifs', async (_event, payload = {}) => {
   if (!payload.ifsPath || typeof payload.ifsPath !== 'string') {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ type View = "validate" | "tune";
 type TuneIFsPageProps = {
   onBack: () => void;
   validatedPath: string;
+  validatedInputPath: string;
   baseYear?: number | null;
   outputDirectory: string | null;
   requestOutputDirectory: () => Promise<string | null>;
@@ -59,6 +60,7 @@ function calculateProgressPercentage(
 function TuneIFsPage({
   onBack,
   validatedPath,
+  validatedInputPath,
   baseYear,
   outputDirectory,
   requestOutputDirectory,
@@ -225,6 +227,18 @@ function TuneIFsPage({
 
     setError(null);
 
+    if (!validatedPath || !validatedPath.trim()) {
+      setError("Validated IFs folder path is missing. Please re-run validation.");
+      return;
+    }
+
+    if (!validatedInputPath || !validatedInputPath.trim()) {
+      setError(
+        "Validated input file path is missing. Please re-run validation to continue.",
+      );
+      return;
+    }
+
     const parsedEndYear = Number(endYearInput);
     if (!Number.isFinite(parsedEndYear) || parsedEndYear <= 0) {
       setError("Please enter a valid end year.");
@@ -246,6 +260,8 @@ function TuneIFsPage({
         parameters: parameterRef.current,
         coefficients: coefficientRef.current,
         paramDim: paramDimensionRef.current,
+        validatedPath,
+        inputFilePath: validatedInputPath,
       });
 
       if (response.status === "success") {
@@ -1013,7 +1029,12 @@ function App() {
       {view === "tune" && result?.valid && (
         <TuneIFsPage
           onBack={() => setView("validate")}
-          validatedPath={ifsFolderPath?.trim() ?? ""}
+          validatedPath={
+            lastValidatedIfsFolder ?? ifsFolderPath?.trim() ?? ""
+          }
+          validatedInputPath={
+            lastValidatedInputFile ?? inputFilePath?.trim() ?? ""
+          }
           baseYear={result?.base_year}
           outputDirectory={outputDirectory}
           requestOutputDirectory={requestOutputDirectory}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -116,12 +116,16 @@ export async function modelSetup({
   parameters,
   coefficients,
   paramDim,
+  validatedPath,
+  inputFilePath,
 }: {
   baseYear: number | null | undefined;
   endYear: number;
   parameters?: Record<string, unknown>;
   coefficients?: Record<string, unknown>;
   paramDim?: Record<string, unknown>;
+  validatedPath: string;
+  inputFilePath: string;
 }): Promise<ModelSetupResponse> {
   if (!window.electron?.invoke) {
     return {
@@ -137,6 +141,8 @@ export async function modelSetup({
       parameters: parameters ?? {},
       coefficients: coefficients ?? {},
       param_dim_dict: paramDim ?? {},
+      validatedPath,
+      inputFilePath,
     };
     const result = await window.electron.invoke("model_setup", payload);
     if (result && typeof result === "object" && "status" in result) {


### PR DESCRIPTION
## Summary
- validate the model_setup IPC payload and call backend/model_setup.py with the validated IFs root and input file arguments
- surface the validated IFs folder and input file paths from the validation step when invoking model setup from the tuning workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dda345ce1c83279d65af1f41457263