### PR TITLE
Forward base and end year arguments to model setup

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -583,7 +583,19 @@ ipcMain.handle('model_setup', async (_event, payload) => {
     throw new Error('model_setup requires an inputFilePath');
   }
 
-  const args = ['--ifs-root', validatedPath, '--input-file', inputFilePath];
+  const baseYear = payload.baseYear ?? null;
+  const endYear = payload.endYear;
+
+  const args = [
+    '--ifs-root',
+    validatedPath,
+    '--input-file',
+    inputFilePath,
+    '--base-year',
+    String(baseYear ?? ''),
+    '--end-year',
+    String(endYear),
+  ];
   return runPythonScript('model_setup.py', args);
 });
 


### PR DESCRIPTION
## Summary
- ensure the Electron IPC handler for `model_setup` forwards the base and end year arguments to `model_setup.py`
- stringify the provided years before invoking the Python script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddaa5dee588327a1f67d976c0619a0