### PR TITLE
Fix handling of IFsVar switch and variable columns

### DIFF
--- a/backend/model_setup.py
+++ b/backend/model_setup.py
@@ -71,10 +71,13 @@ def _load_sheet(path: Path, sheet_name: str) -> pd.DataFrame:
 
 
 def _is_enabled(value: Any) -> bool:
-    if value is None:
+    if value is None or pd.isna(value):
         return False
     if isinstance(value, (int, float)):
-        return int(value) == 1
+        try:
+            return int(value) == 1
+        except (TypeError, ValueError):
+            return False
     normalized = str(value).strip().lower()
     return normalized in {"1", "on"}
 

--- a/backend/model_setup.py
+++ b/backend/model_setup.py
@@ -75,7 +75,8 @@ def _is_enabled(value: Any) -> bool:
         return False
     if isinstance(value, (int, float)):
         return int(value) == 1
-    return str(value).strip() == "1"
+    normalized = str(value).strip().lower()
+    return normalized in {"1", "on"}
 
 
 def _normalize_number(value: Any) -> Optional[float]:
@@ -249,12 +250,10 @@ def add_from_startingpoint(ifs_root: Path, excel_path: Path) -> int:
 
     for _, row in df.iterrows():
         switch_value = row.get("Switch")
-        if not isinstance(switch_value, str):
-            switch_value = "" if switch_value is None else str(switch_value)
-        if switch_value.strip().lower() != "on":
+        if not _is_enabled(switch_value):
             continue
 
-        variable = row.get("Variable")
+        variable = row.get("Variable") or row.get("Name")
         if not isinstance(variable, str) or not variable.strip():
             continue
 


### PR DESCRIPTION
## Summary
- accept both numeric and "on" values when evaluating IFsVar switch entries
- read IFsVar variables from either the "Variable" or "Name" column so selected rows populate Working.sce

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de06f8fc84832781b2f97ba37e98c7