### PR TITLE
Ensure run_ifs receives validated path

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -307,6 +307,7 @@ function TuneIFsPage({
     setProgressPercent(0);
 
     const response = await runIFs({
+      validatedPath,
       endYear: clampedEndYear,
       baseYear: baseYearRef.current,
       outputDirectory,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -98,6 +98,7 @@ export async function validateIFsFolder({
 }
 
 export type RunIFsParams = {
+  validatedPath: string;
   endYear: number;
   baseYear: number | null | undefined;
   outputDirectory: string;
@@ -161,6 +162,7 @@ export async function modelSetup({
 }
 
 export async function runIFs({
+  validatedPath,
   endYear,
   baseYear,
   outputDirectory,
@@ -176,6 +178,10 @@ export async function runIFs({
 
   try {
     const payload = await window.electron.invoke("run_ifs", {
+      validatedPath,
+      endYear,
+      baseYear: baseYear ?? null,
+      outputDirectory,
       end_year: endYear,
       base_year: baseYear ?? null,
       output_dir: outputDirectory,


### PR DESCRIPTION
## Summary
- pass the validated IFs root path from the UI when triggering a run
- include the validated path in the IPC payload so run_ifs.py receives the --ifs-root argument

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de0b84caa4832782263fbdab2e4fd3