### PR TITLE
Improve Tune IFs page messaging and responsiveness

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -13,11 +13,18 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
+    minWidth: 960,
+    minHeight: 700,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
+  });
+
+  mainWindow.setResizable(true);
+  mainWindow.on('resize', () => {
+    mainWindow.webContents.send('window-resized');
   });
 
   mainWindow.on('closed', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,7 +80,7 @@ function TuneIFsPage({
   const [progressPercent, setProgressPercent] = useState(0);
   const [metadata, setMetadata] = useState<RunIFsSuccess | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [setupMessage, setSetupMessage] = useState("Waiting to start.");
+  const [setupMessage, setSetupMessage] = useState("");
   const [effectiveBaseYear, setEffectiveBaseYear] = useState<number | null>(
     typeof baseYear === "number" && Number.isFinite(baseYear) ? baseYear : null,
   );
@@ -104,6 +104,10 @@ function TuneIFsPage({
     baseYearRef.current = normalized;
     setEffectiveBaseYear(normalized);
   }, [baseYear]);
+
+  useEffect(() => {
+    setSetupMessage("Waiting to start.");
+  }, [validatedPath, validatedInputPath, outputDirectory]);
 
   useEffect(() => {
     setEndYear((current) => {
@@ -368,7 +372,7 @@ function TuneIFsPage({
           baseYearRef.current = response.base_year;
           setEffectiveBaseYear(response.base_year);
         }
-        setSetupMessage("Waiting to start.");
+        setSetupMessage("Run completed.");
       } else {
         setError(response.message ?? "IFs run failed.");
         setSetupMessage("❌ Run failed.");

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -16,9 +16,21 @@ body {
 }
 
 .container {
-  max-width: 720px;
+  max-width: 90%;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 2rem 1rem;
+}
+
+@media (min-width: 1200px) {
+  .container {
+    max-width: 900px;
+  }
+}
+
+@media (max-width: 800px) {
+  .container {
+    padding: 1.5rem 1rem;
+  }
 }
 
 .header {
@@ -496,6 +508,24 @@ body {
 .progress-indicator::-moz-progress-bar {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   border-radius: 9999px;
+}
+
+.metadata-inline {
+  margin-top: 1rem;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(203, 213, 224, 0.7);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.metadata-inline li {
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+  word-break: break-all;
 }
 
 .metadata {


### PR DESCRIPTION
## Summary
- ensure the Tune IFs setup message only resets when the user revisits or changes folders and report completion after a run
- wrap metadata details and update the container layout for better responsive scaling
- enforce a minimum Electron window size and emit resize events for renderer adjustments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e58b1978608327af2a13b6f2ec955e