### PR TITLE
Avoid duplicate run status messages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -349,7 +349,7 @@ function TuneIFsPage({
     setEndYear(clampedEndYear);
     setEndYearInput(String(clampedEndYear));
     setModelSetupResult(null);
-    setSetupMessage("Running IFs…");
+    setSetupMessage("");
     setRunning(true);
 
     try {
@@ -372,7 +372,7 @@ function TuneIFsPage({
           baseYearRef.current = response.base_year;
           setEffectiveBaseYear(response.base_year);
         }
-        setSetupMessage("Run completed.");
+        setSetupMessage("✅ Run completed.");
       } else {
         setError(response.message ?? "IFs run failed.");
         setSetupMessage("❌ Run failed.");
@@ -394,7 +394,7 @@ function TuneIFsPage({
       ? `Running IFs… Last reported year: ${progressYear} (${formattedPercent})`
       : "Running IFs…"
     : metadata
-    ? "Run completed."
+    ? null
     : progressYear != null
     ? `Last reported year: ${progressYear} (${formattedPercent})`
     : null;


### PR DESCRIPTION
## Summary
- clear the setup status text when an IFs run begins so only the progress label shows the running message
- stop rendering the progress label after completion and show a single success status with the proper style

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e58d312a6c8327a7b1c3668e38a1d2